### PR TITLE
Add a start-deamon command that only starts the daemon (instead of start)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 yarn exec lint-staged
+npm run lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,3 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 yarn exec lint-staged
-npm run lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# [Next]
+
+## Highlights
+
+- Add `--only` flag to start specific microservices
+
+# 1.0.0
+
+Initial release

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ $ npx dev-process-manager start [path-to-dev-pm.config.js]
 
 The path to the config file can be specified in an optional parameter. "dev-pm.config.js" in the root directory is used by default.
 
+#### Options
+Only start specified scripts. Accepts one or more script names.
+```console
+$ npx dev-process-manager start --only api admin
+```
+
+
 ### Stop
 
 Stop all running processes

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
         "ts-node": "^10.4.0"
     },
     "devDependencies": {
-        "@comet/eslint-config": "^2.0.1-canary.100.0",
+        "@comet/eslint-config": "^3.0.0-canary.344.0",
         "@types/node": "^14.0.0",
-        "eslint": "^8.0.0",
+        "eslint": "^8.20.0",
         "husky": "^8.0.0",
         "lint-staged": "^12.0.0",
         "prettier": "^2.0.0",

--- a/src/commands/auto-start-deamon.ts
+++ b/src/commands/auto-start-deamon.ts
@@ -1,0 +1,15 @@
+import { spawn } from "child_process";
+import { existsSync } from "fs";
+
+export async function autoStartDaemon(): Promise<void> {
+    if (existsSync("./.pm.sock")) {
+        // socket file already exists, we assume daemon is already running
+        return;
+    }
+    console.log("starting dev-pm daemon...");
+    const child = spawn(process.argv[0], [process.argv[1], "start-daemon"], { detached: true, stdio: ["ignore", "ignore", "ignore"] });
+    child.unref();
+    while (!existsSync("./.pm.sock")) {
+        await new Promise((r) => setTimeout(r, 100));
+    }
+}

--- a/src/commands/start-daemon.command.ts
+++ b/src/commands/start-daemon.command.ts
@@ -1,0 +1,84 @@
+import { ChildProcess } from "child_process";
+import colors from "colors";
+import { existsSync } from "fs";
+import { createServer, Server, Socket } from "net";
+
+import { logsDaemonCommand } from "../daemon-command/logs.daemon-command";
+import { restartDaemonCommand } from "../daemon-command/restart.daemon-command";
+import { shutdown } from "../daemon-command/shutdown";
+import { shutdownDaemonCommand } from "../daemon-command/shutdown.daemon-command";
+import { startDaemonCommand } from "../daemon-command/start.deamon-command";
+import { statusDaemonCommand } from "../daemon-command/status.daemon-command";
+import { ScriptDefinition } from "../script-definition.type";
+
+export interface Daemon {
+    logSockets: { socket: Socket; name: string | null }[];
+    scripts: ScriptDefinition[];
+    processes: { [key: string]: ChildProcess };
+    shuttingDown: boolean;
+    server?: Server;
+}
+
+export const startDaemon = async (pmConfigFilePathOverride?: string): Promise<void> => {
+    const pmConfigFilePath = pmConfigFilePathOverride ? pmConfigFilePathOverride : "dev-pm.config.js";
+    const { scripts }: { scripts: ScriptDefinition[] } = await import(`${process.cwd()}/${pmConfigFilePath}`);
+    const processes: { [key: string]: ChildProcess } = {};
+    const logSockets: { socket: Socket; name: string | null }[] = [];
+    const daemon: Daemon = {
+        logSockets,
+        scripts,
+        processes,
+        shuttingDown: false,
+        server: undefined,
+    };
+
+    if (existsSync("./.pm.sock")) {
+        console.log(
+            "Could not start dev-pm server. A '.pm.sock' file already exists. \nThere are 2 possible reasons for this:\nA: Another dev-pm instance is already running. \nB: dev-pm crashed and left the file behind. In this case please remove the file manually.",
+        );
+        return;
+    }
+
+    daemon.server = createServer();
+    daemon.server.listen(".pm.sock");
+    daemon.server.on("connection", (s) => {
+        s.on("data", async (command) => {
+            const cmd = command.toString();
+
+            if (cmd == "logs" || cmd.startsWith("logs ")) {
+                const scriptName = cmd != "logs" ? cmd.substring(5) : null; // null means all
+                logsDaemonCommand(daemon, s, scriptName);
+            } else if (cmd.startsWith("restart ")) {
+                const scriptName = cmd.substring(8);
+                restartDaemonCommand(daemon, s, scriptName);
+            } else if (cmd.startsWith("start ")) {
+                const options = JSON.parse(cmd.substring(6));
+                startDaemonCommand(daemon, s, options);
+            } else if (cmd == "status") {
+                statusDaemonCommand(daemon, s);
+            } else if (cmd == "shutdown") {
+                shutdownDaemonCommand(daemon, s);
+            } else {
+                console.log(`${colors.bgYellow.bold.black(" dev-pm ")} unknown command ${cmd}`);
+            }
+        });
+    });
+    console.log(`${colors.bgYellow.bold.black(" dev-pm ")} daemon started, listening for connections in .pm.sock`);
+
+    process.on("SIGINT", function () {
+        shutdown(daemon);
+    });
+
+    process.on("SIGTERM", function () {
+        shutdown(daemon);
+    });
+
+    const events = ["beforeExit", "disconnected", "message", "rejectionHandled", "uncaughtException", "SIGABRT", "SIGHUP", "SIGPWR", "SIGQUIT"];
+
+    events.forEach((eventName) => {
+        process.on(eventName, (...args) => {
+            console.log(`${colors.bgRed.bold.black(" dev-pm ")} unhandled error event "${eventName}" was called with args: ${args.join(",")}`);
+            shutdown(daemon);
+        });
+    });
+};

--- a/src/commands/start.command.ts
+++ b/src/commands/start.command.ts
@@ -1,17 +1,37 @@
-import { ChildProcess, execSync, spawn } from "child_process";
-import CLITable from "cli-table3";
+import { ChildProcess } from "child_process";
 import colors from "colors";
 import { existsSync } from "fs";
-import { createServer, Socket } from "net";
+import { createServer, Server, Socket } from "net";
+import { logsDaemonCommand } from "src/daemon-command/logs.daemon-command";
+import { restartDaemonCommand } from "src/daemon-command/restart.daemon-command";
+import { shutdown } from "src/daemon-command/shutdown";
+import { shutdownDaemonCommand } from "src/daemon-command/shutdown.daemon-command";
+import { startProcess } from "src/daemon-command/start-process";
+import { statusDaemonCommand } from "src/daemon-command/status.daemon-command";
 
 import { ScriptDefinition } from "../script-definition.type";
+
+export interface Daemon {
+    logSockets: { socket: Socket; name: string | null }[];
+    scripts: ScriptDefinition[];
+    processes: { [key: string]: ChildProcess };
+    shuttingDown: boolean;
+    server?: Server;
+}
 
 export const start = async (pmConfigFilePathOverride?: string, options?: { only?: string[]; onlyGroup?: string[] }): Promise<void> => {
     const pmConfigFilePath = pmConfigFilePathOverride ? pmConfigFilePathOverride : "dev-pm.config.js";
     const { scripts }: { scripts: ScriptDefinition[] } = await import(`${process.cwd()}/${pmConfigFilePath}`);
     const processes: { [key: string]: ChildProcess } = {};
     const logSockets: { socket: Socket; name: string | null }[] = [];
-    let shuttingDown = false;
+    const daemon: Daemon = {
+        logSockets,
+        scripts,
+        processes,
+        shuttingDown: false,
+        server: undefined,
+    };
+
     const scriptsToStart: ScriptDefinition[] = scripts.filter((script) => {
         if (options?.only && options.only.length > 0) {
             if (!options.only.includes(script.name)) return false;
@@ -26,40 +46,6 @@ export const start = async (pmConfigFilePathOverride?: string, options?: { only?
         return true;
     });
 
-    function startProcess(script: ScriptDefinition): void {
-        console.log(`${colors.bgGreen.bold.black(" dev-pm ")} starting: ${script.script}`);
-        const NPM_PATH = execSync("npm bin").toString().trim();
-        const p = spawn("bash", ["-c", script.script], { detached: true, env: { ...process.env, PATH: `${NPM_PATH}:${process.env.PATH}` } });
-        p.stdout.on("data", (data) => {
-            process.stdout.write(data);
-            logSockets.forEach((s) => {
-                if (!s.name || s.name == script.name) {
-                    s.socket.write(`${s.name}: ${data}`);
-                }
-            });
-        });
-        p.stderr.on("data", (data) => {
-            process.stderr.write(data);
-            logSockets.forEach((s) => {
-                if (!s.name || s.name == script.name) {
-                    s.socket.write(`${s.name}: ${data}`);
-                }
-            });
-        });
-        p.on("close", () => {
-            if (!shuttingDown) {
-                console.log(`${colors.bgRed.bold.black(" dev-pm ")} process stopped ${script.name}, restarting...`);
-                startProcess(script);
-            }
-        });
-        p.on("error", (err) => {
-            // TODO handle
-            console.error(err);
-            console.log(`${colors.bgRed.bold.black(" dev-pm ")} Failed starting process  ${script.name}`);
-        });
-        processes[script.name] = p;
-    }
-
     if (existsSync("./.pm.sock")) {
         console.log(
             "Could not start dev-pm server. A '.pm.sock' file already exists. \nThere are 2 possible reasons for this:\nA: Another dev-pm instance is already running. \nB: dev-pm crashed and left the file behind. In this case please remove the file manually.",
@@ -67,71 +53,22 @@ export const start = async (pmConfigFilePathOverride?: string, options?: { only?
         return;
     }
 
-    const server = createServer();
-    server.listen(".pm.sock");
-    server.on("connection", (s) => {
+    daemon.server = createServer();
+    daemon.server.listen(".pm.sock");
+    daemon.server.on("connection", (s) => {
         s.on("data", async (command) => {
             const cmd = command.toString();
+
             if (cmd == "logs" || cmd.startsWith("logs ")) {
-                const name = cmd != "logs" ? cmd.substring(5) : null; // null means all
-                if (name && !scripts.find((script) => script.name === name)) {
-                    console.error("Unknown name");
-                } else {
-                    logSockets.push({ socket: s, name });
-                    s.on("close", () => {
-                        const index = logSockets.findIndex((i) => i.socket == s);
-                        if (index !== -1) {
-                            logSockets.splice(index, 1);
-                        }
-                    });
-                }
+                const scriptName = cmd != "logs" ? cmd.substring(5) : null; // null means all
+                logsDaemonCommand(daemon, s, scriptName);
             } else if (cmd.startsWith("restart ")) {
-                const name = cmd.substring(8);
-                const p = processes[name];
-                if (!p) {
-                    console.log(`${colors.bgYellow.bold.black(" dev-pm ")} unknown name  ${name}`);
-                    s.end();
-                    return;
-                }
-
-                if (!p.killed) {
-                    console.log(`${colors.bgYellow.bold.black(" dev-pm ")} killing ${name}`);
-                    p.kill("SIGINT");
-                    while (!p.killed) {
-                        console.log(`${colors.bgYellow.bold.black(" dev-pm ")} waiting for killed`);
-                        await new Promise((r) => setTimeout(r, 100));
-                    }
-                }
-
-                const script = scripts.find((i) => i.name == name);
-                if (!script) {
-                    console.log(`${colors.bgYellow.bold.black(" dev-pm ")} unknown name  ${name}`);
-                    s.end();
-                    return;
-                }
-                startProcess(script);
-                s.end();
+                const scriptName = cmd.substring(8);
+                restartDaemonCommand(daemon, s, scriptName);
             } else if (cmd == "status") {
-                const response = Object.keys(processes).map((name) => {
-                    const p = processes[name];
-                    return {
-                        name,
-                        running: !p.killed,
-                        pid: p.pid,
-                    };
-                });
-
-                const table = new CLITable({
-                    head: [colors.blue.bold("Script"), colors.blue.bold("Status"), colors.bold.blue("PID")],
-                    colWidths: [100, 20, 20],
-                });
-                response.forEach((item) => {
-                    table.push([item.name, item.running ? colors.green("Running") : colors.red("Stopped"), item.pid?.toString()]);
-                });
-                s.write(table.toString());
-                s.end();
+                statusDaemonCommand(daemon, s);
             } else if (cmd == "shutdown") {
-                shutdown(s);
+                shutdownDaemonCommand(daemon, s);
             } else {
                 console.log(`${colors.bgYellow.bold.black(" dev-pm ")} unknown command ${cmd}`);
             }
@@ -139,15 +76,15 @@ export const start = async (pmConfigFilePathOverride?: string, options?: { only?
     });
 
     scriptsToStart.forEach((script) => {
-        startProcess(script);
+        startProcess(daemon, script);
     });
 
     process.on("SIGINT", function () {
-        shutdown();
+        shutdown(daemon);
     });
 
     process.on("SIGTERM", function () {
-        shutdown();
+        shutdown(daemon);
     });
 
     const events = ["beforeExit", "disconnected", "message", "rejectionHandled", "uncaughtException", "SIGABRT", "SIGHUP", "SIGPWR", "SIGQUIT"];
@@ -155,22 +92,7 @@ export const start = async (pmConfigFilePathOverride?: string, options?: { only?
     events.forEach((eventName) => {
         process.on(eventName, (...args) => {
             console.log(`${colors.bgRed.bold.black(" dev-pm ")} unhandled error event "${eventName}" was called with args: ${args.join(",")}`);
-            shutdown();
+            shutdown(daemon);
         });
     });
-
-    const shutdown = async (s?: Socket): Promise<void> => {
-        console.log(`${colors.bgGreen.bold.black(" dev-pm ")} shutting down`);
-        shuttingDown = true;
-        await Promise.all(
-            Object.values(processes).map(async (p) => {
-                if (p.pid) {
-                    process.kill(-p.pid);
-                }
-            }),
-        );
-        server.close();
-        s?.destroy();
-        process.exit();
-    };
 };

--- a/src/commands/start.command.ts
+++ b/src/commands/start.command.ts
@@ -1,98 +1,16 @@
-import { ChildProcess } from "child_process";
-import colors from "colors";
-import { existsSync } from "fs";
-import { createServer, Server, Socket } from "net";
-import { logsDaemonCommand } from "src/daemon-command/logs.daemon-command";
-import { restartDaemonCommand } from "src/daemon-command/restart.daemon-command";
-import { shutdown } from "src/daemon-command/shutdown";
-import { shutdownDaemonCommand } from "src/daemon-command/shutdown.daemon-command";
-import { startProcess } from "src/daemon-command/start-process";
-import { statusDaemonCommand } from "src/daemon-command/status.daemon-command";
+import { createConnection } from "net";
 
-import { ScriptDefinition } from "../script-definition.type";
+import { autoStartDaemon } from "./auto-start-deamon";
 
-export interface Daemon {
-    logSockets: { socket: Socket; name: string | null }[];
-    scripts: ScriptDefinition[];
-    processes: { [key: string]: ChildProcess };
-    shuttingDown: boolean;
-    server?: Server;
-}
+export const start = async (options?: { only?: string[]; onlyGroup?: string[] }): Promise<void> => {
+    await autoStartDaemon();
 
-export const start = async (pmConfigFilePathOverride?: string, options?: { only?: string[]; onlyGroup?: string[] }): Promise<void> => {
-    const pmConfigFilePath = pmConfigFilePathOverride ? pmConfigFilePathOverride : "dev-pm.config.js";
-    const { scripts }: { scripts: ScriptDefinition[] } = await import(`${process.cwd()}/${pmConfigFilePath}`);
-    const processes: { [key: string]: ChildProcess } = {};
-    const logSockets: { socket: Socket; name: string | null }[] = [];
-    const daemon: Daemon = {
-        logSockets,
-        scripts,
-        processes,
-        shuttingDown: false,
-        server: undefined,
-    };
-
-    const scriptsToStart: ScriptDefinition[] = scripts.filter((script) => {
-        if (options?.only && options.only.length > 0) {
-            if (!options.only.includes(script.name)) return false;
-        }
-        if (options?.onlyGroup && options.onlyGroup.length > 0) {
-            const scriptGroups = Array.isArray(script.group) ? script.group : [script.group];
-            return scriptGroups.some((g) => {
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                return options.onlyGroup!.includes(g);
-            });
-        }
-        return true;
+    const client = createConnection(".pm.sock");
+    client.on("connect", () => {
+        client.write(`start ${JSON.stringify(options)}`);
     });
-
-    if (existsSync("./.pm.sock")) {
-        console.log(
-            "Could not start dev-pm server. A '.pm.sock' file already exists. \nThere are 2 possible reasons for this:\nA: Another dev-pm instance is already running. \nB: dev-pm crashed and left the file behind. In this case please remove the file manually.",
-        );
-        return;
-    }
-
-    daemon.server = createServer();
-    daemon.server.listen(".pm.sock");
-    daemon.server.on("connection", (s) => {
-        s.on("data", async (command) => {
-            const cmd = command.toString();
-
-            if (cmd == "logs" || cmd.startsWith("logs ")) {
-                const scriptName = cmd != "logs" ? cmd.substring(5) : null; // null means all
-                logsDaemonCommand(daemon, s, scriptName);
-            } else if (cmd.startsWith("restart ")) {
-                const scriptName = cmd.substring(8);
-                restartDaemonCommand(daemon, s, scriptName);
-            } else if (cmd == "status") {
-                statusDaemonCommand(daemon, s);
-            } else if (cmd == "shutdown") {
-                shutdownDaemonCommand(daemon, s);
-            } else {
-                console.log(`${colors.bgYellow.bold.black(" dev-pm ")} unknown command ${cmd}`);
-            }
-        });
-    });
-
-    scriptsToStart.forEach((script) => {
-        startProcess(daemon, script);
-    });
-
-    process.on("SIGINT", function () {
-        shutdown(daemon);
-    });
-
-    process.on("SIGTERM", function () {
-        shutdown(daemon);
-    });
-
-    const events = ["beforeExit", "disconnected", "message", "rejectionHandled", "uncaughtException", "SIGABRT", "SIGHUP", "SIGPWR", "SIGQUIT"];
-
-    events.forEach((eventName) => {
-        process.on(eventName, (...args) => {
-            console.log(`${colors.bgRed.bold.black(" dev-pm ")} unhandled error event "${eventName}" was called with args: ${args.join(",")}`);
-            shutdown(daemon);
-        });
+    client.on("data", (data) => {
+        //TODO handle stderr/stdin and also write on stderr
+        process.stdout.write(data);
     });
 };

--- a/src/commands/start.command.ts
+++ b/src/commands/start.command.ts
@@ -22,7 +22,7 @@ export const start = async (pmConfigFilePathOverride?: string, options?: { only?
             } else {
                 console.log(`${colors.bgRed.bold.black(" dev-pm ")} Script ${scriptName} not found in dev-pm config`);
             }
-        })
+        });
     } else {
         scriptsToStart = scripts;
     }

--- a/src/commands/start.command.ts
+++ b/src/commands/start.command.ts
@@ -20,7 +20,8 @@ export const start = async (pmConfigFilePathOverride?: string, options?: { only?
             if (foundScript) {
                 scriptsToStart.push(foundScript);
             } else {
-                console.log(`${colors.bgRed.bold.black(" dev-pm ")} Script ${scriptName} not found in dev-pm config`);
+                console.error(`${colors.bgRed.bold.black(" dev-pm ")} Script ${scriptName} not found in dev-pm config`);
+                process.exit(1);
             }
         });
     } else {

--- a/src/commands/start.command.ts
+++ b/src/commands/start.command.ts
@@ -6,12 +6,26 @@ import { createServer, Socket } from "net";
 
 import { ScriptDefinition } from "../script-definition.type";
 
-export const start = async (pmConfigFilePathOverride?: string): Promise<void> => {
+export const start = async (pmConfigFilePathOverride?: string, options?: { only?: string[] }): Promise<void> => {
     const pmConfigFilePath = pmConfigFilePathOverride ? pmConfigFilePathOverride : "dev-pm.config.js";
     const { scripts }: { scripts: ScriptDefinition[] } = await import(`${process.cwd()}/${pmConfigFilePath}`);
     const processes: { [key: string]: ChildProcess } = {};
     const logSockets: { socket: Socket; name: string | null }[] = [];
     let shuttingDown = false;
+    let scriptsToStart: ScriptDefinition[] = [];
+
+    if (options?.only && options?.only?.length > 0) {
+        options.only.map((scriptName) => {
+            const foundScript = scripts.find((script) => script.name === scriptName);
+            if (foundScript) {
+                scriptsToStart.push(foundScript);
+            } else {
+                console.log(`${colors.bgRed.bold.black(" dev-pm ")} Script ${scriptName} not found in dev-pm config`);
+            }
+        })
+    } else {
+        scriptsToStart = scripts;
+    }
 
     function startProcess(script: ScriptDefinition): void {
         console.log(`${colors.bgGreen.bold.black(" dev-pm ")} starting: ${script.script}`);
@@ -125,7 +139,7 @@ export const start = async (pmConfigFilePathOverride?: string): Promise<void> =>
         });
     });
 
-    scripts.forEach((script) => {
+    scriptsToStart.forEach((script) => {
         startProcess(script);
     });
 

--- a/src/daemon-command/logs.daemon-command.ts
+++ b/src/daemon-command/logs.daemon-command.ts
@@ -1,0 +1,17 @@
+import colors from "colors";
+import { Socket } from "net";
+import { Daemon } from "src/commands/start.command";
+
+export function logsDaemonCommand({ logSockets, scripts }: Daemon, socket: Socket, scriptName: string | null /* null means all */): void {
+    if (scriptName && !scripts.find((script) => script.name === scriptName)) {
+        console.log(`${colors.bgYellow.bold.black(" dev-pm ")} unknown script name  ${scriptName}`);
+    } else {
+        logSockets.push({ socket, name: scriptName });
+        socket.on("close", () => {
+            const index = logSockets.findIndex((i) => i.socket == socket);
+            if (index !== -1) {
+                logSockets.splice(index, 1);
+            }
+        });
+    }
+}

--- a/src/daemon-command/logs.daemon-command.ts
+++ b/src/daemon-command/logs.daemon-command.ts
@@ -1,6 +1,7 @@
 import colors from "colors";
 import { Socket } from "net";
-import { Daemon } from "src/commands/start.command";
+
+import { Daemon } from "../commands/start-daemon.command";
 
 export function logsDaemonCommand({ logSockets, scripts }: Daemon, socket: Socket, scriptName: string | null /* null means all */): void {
     if (scriptName && !scripts.find((script) => script.name === scriptName)) {

--- a/src/daemon-command/restart.daemon-command.ts
+++ b/src/daemon-command/restart.daemon-command.ts
@@ -1,0 +1,33 @@
+import colors from "colors";
+import { Socket } from "net";
+import { Daemon } from "src/commands/start.command";
+
+import { startProcess } from "./start-process";
+
+export async function restartDaemonCommand(daemon: Daemon, socket: Socket, scriptName: string): Promise<void> {
+    const { scripts, processes } = daemon;
+    const p = processes[scriptName];
+    if (!p) {
+        console.log(`${colors.bgYellow.bold.black(" dev-pm ")} unknown script name  ${scriptName}`);
+        socket.end();
+        return;
+    }
+
+    if (!p.killed) {
+        console.log(`${colors.bgYellow.bold.black(" dev-pm ")} killing ${scriptName}`);
+        p.kill("SIGINT");
+        while (!p.killed) {
+            console.log(`${colors.bgYellow.bold.black(" dev-pm ")} waiting for killed`);
+            await new Promise((r) => setTimeout(r, 100));
+        }
+    }
+
+    const script = scripts.find((i) => i.name == scriptName);
+    if (!script) {
+        console.log(`${colors.bgYellow.bold.black(" dev-pm ")} unknown script name  ${scriptName}`);
+        socket.end();
+        return;
+    }
+    startProcess(daemon, script);
+    socket.end();
+}

--- a/src/daemon-command/shutdown.daemon-command.ts
+++ b/src/daemon-command/shutdown.daemon-command.ts
@@ -1,6 +1,6 @@
 import { Socket } from "net";
-import { Daemon } from "src/commands/start.command";
 
+import { Daemon } from "../commands/start-daemon.command";
 import { shutdown } from "./shutdown";
 
 export function shutdownDaemonCommand(daemon: Daemon, socket: Socket): void {

--- a/src/daemon-command/shutdown.daemon-command.ts
+++ b/src/daemon-command/shutdown.daemon-command.ts
@@ -1,0 +1,9 @@
+import { Socket } from "net";
+import { Daemon } from "src/commands/start.command";
+
+import { shutdown } from "./shutdown";
+
+export function shutdownDaemonCommand(daemon: Daemon, socket: Socket): void {
+    socket.destroy(); //probably too early, doesn't allow us to send output
+    shutdown(daemon);
+}

--- a/src/daemon-command/shutdown.ts
+++ b/src/daemon-command/shutdown.ts
@@ -1,0 +1,16 @@
+import colors from "colors";
+import { Daemon } from "src/commands/start.command";
+
+export const shutdown = async (daemon: Daemon): Promise<void> => {
+    console.log(`${colors.bgGreen.bold.black(" dev-pm ")} shutting down`);
+    daemon.shuttingDown = true;
+    await Promise.all(
+        Object.values(daemon.processes).map(async (p) => {
+            if (p.pid) {
+                process.kill(-p.pid);
+            }
+        }),
+    );
+    daemon.server?.close();
+    process.exit();
+};

--- a/src/daemon-command/shutdown.ts
+++ b/src/daemon-command/shutdown.ts
@@ -1,5 +1,6 @@
 import colors from "colors";
-import { Daemon } from "src/commands/start.command";
+
+import { Daemon } from "../commands/start-daemon.command";
 
 export const shutdown = async (daemon: Daemon): Promise<void> => {
     console.log(`${colors.bgGreen.bold.black(" dev-pm ")} shutting down`);

--- a/src/daemon-command/start-process.ts
+++ b/src/daemon-command/start-process.ts
@@ -1,7 +1,8 @@
 import { execSync, spawn } from "child_process";
 import colors from "colors";
-import { Daemon } from "src/commands/start.command";
-import { ScriptDefinition } from "src/script-definition.type";
+
+import { Daemon } from "../commands/start-daemon.command";
+import { ScriptDefinition } from "../script-definition.type";
 
 export function startProcess(daemon: Daemon, script: ScriptDefinition): void {
     const { logSockets, processes } = daemon;

--- a/src/daemon-command/start-process.ts
+++ b/src/daemon-command/start-process.ts
@@ -1,0 +1,39 @@
+import { execSync, spawn } from "child_process";
+import colors from "colors";
+import { Daemon } from "src/commands/start.command";
+import { ScriptDefinition } from "src/script-definition.type";
+
+export function startProcess(daemon: Daemon, script: ScriptDefinition): void {
+    const { logSockets, processes } = daemon;
+    console.log(`${colors.bgGreen.bold.black(" dev-pm ")} starting: ${script.script}`);
+    const NPM_PATH = execSync("npm bin").toString().trim();
+    const p = spawn("bash", ["-c", script.script], { detached: true, env: { ...process.env, PATH: `${NPM_PATH}:${process.env.PATH}` } });
+    p.stdout.on("data", (data) => {
+        process.stdout.write(data);
+        logSockets.forEach((s) => {
+            if (!s.name || s.name == script.name) {
+                s.socket.write(`${s.name}: ${data}`);
+            }
+        });
+    });
+    p.stderr.on("data", (data) => {
+        process.stderr.write(data);
+        logSockets.forEach((s) => {
+            if (!s.name || s.name == script.name) {
+                s.socket.write(`${s.name}: ${data}`);
+            }
+        });
+    });
+    p.on("close", () => {
+        if (!daemon.shuttingDown) {
+            console.log(`${colors.bgRed.bold.black(" dev-pm ")} process stopped ${script.name}, restarting...`);
+            startProcess(daemon, script);
+        }
+    });
+    p.on("error", (err) => {
+        // TODO handle
+        console.error(err);
+        console.log(`${colors.bgRed.bold.black(" dev-pm ")} Failed starting process  ${script.name}`);
+    });
+    processes[script.name] = p;
+}

--- a/src/daemon-command/start.deamon-command.ts
+++ b/src/daemon-command/start.deamon-command.ts
@@ -1,0 +1,27 @@
+import { Socket } from "net";
+
+import { Daemon } from "../commands/start-daemon.command";
+import { startProcess } from "./start-process";
+
+export async function startDaemonCommand(daemon: Daemon, socket: Socket, options: { only?: string[]; onlyGroup?: string[] }): Promise<void> {
+    const scriptsToStart = daemon.scripts.filter((script) => {
+        if (options?.only && options.only.length > 0) {
+            if (!options.only.includes(script.name)) return false;
+        }
+        if (options?.onlyGroup && options.onlyGroup.length > 0) {
+            const scriptGroups = Array.isArray(script.group) ? script.group : [script.group];
+            return scriptGroups.some((g) => {
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                return options.onlyGroup!.includes(g);
+            });
+        }
+        return true;
+    });
+
+    scriptsToStart.forEach((script) => {
+        socket.write(`starting ${script.name}...\n`);
+        startProcess(daemon, script);
+    });
+
+    socket.end();
+}

--- a/src/daemon-command/status.daemon-command.ts
+++ b/src/daemon-command/status.daemon-command.ts
@@ -1,21 +1,23 @@
 import CLITable from "cli-table3";
 import colors from "colors";
 import { Socket } from "net";
-import { Daemon } from "src/commands/start.command";
 
-export function statusDaemonCommand({ processes }: Daemon, socket: Socket): void {
-    const response = Object.keys(processes).map((name) => {
-        const p = processes[name];
+import { Daemon } from "../commands/start-daemon.command";
+
+export function statusDaemonCommand({ processes, scripts }: Daemon, socket: Socket): void {
+    const response = scripts.map((script) => {
+        const process = processes[script.name];
         return {
-            name,
-            running: !p.killed,
-            pid: p.pid,
+            name: script.name,
+            running: process ? !process.killed : false,
+            pid: process ? process.pid : undefined,
         };
     });
 
     const table = new CLITable({
         head: [colors.blue.bold("Script"), colors.blue.bold("Status"), colors.bold.blue("PID")],
         colWidths: [100, 20, 20],
+        style: { compact: true },
     });
     response.forEach((item) => {
         table.push([item.name, item.running ? colors.green("Running") : colors.red("Stopped"), item.pid?.toString()]);

--- a/src/daemon-command/status.daemon-command.ts
+++ b/src/daemon-command/status.daemon-command.ts
@@ -1,0 +1,25 @@
+import CLITable from "cli-table3";
+import colors from "colors";
+import { Socket } from "net";
+import { Daemon } from "src/commands/start.command";
+
+export function statusDaemonCommand({ processes }: Daemon, socket: Socket): void {
+    const response = Object.keys(processes).map((name) => {
+        const p = processes[name];
+        return {
+            name,
+            running: !p.killed,
+            pid: p.pid,
+        };
+    });
+
+    const table = new CLITable({
+        head: [colors.blue.bold("Script"), colors.blue.bold("Status"), colors.bold.blue("PID")],
+        colWidths: [100, 20, 20],
+    });
+    response.forEach((item) => {
+        table.push([item.name, item.running ? colors.green("Running") : colors.red("Stopped"), item.pid?.toString()]);
+    });
+    socket.write(table.toString());
+    socket.end();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,15 +3,16 @@
 import { Command } from "commander";
 
 import { logs, restart, shutdown, start, status } from "./commands";
+import { startDaemon } from "./commands/start-daemon.command";
 
 const program = new Command();
 
 program
-    .command("start [pmConfigFilePath]")
+    .command("start")
     .option("--only <scripts...>", "Only start specified scripts")
     .option("--onlyGroup <groups...>", "Only start scripts in specified group")
-    .action((pmConfigFilePath, options) => {
-        start(pmConfigFilePath, options);
+    .action((options) => {
+        start(options);
     });
 
 program.command("logs [name]").action((name) => {
@@ -28,6 +29,10 @@ program.command("restart <name>").action((name) => {
 
 program.command("stop").action(() => {
     shutdown();
+});
+
+program.command("start-daemon").action(() => {
+    startDaemon();
 });
 
 program.parse(process.argv);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,8 @@ const program = new Command();
 
 program
     .command("start [pmConfigFilePath]")
-    .option("--only <scripts...>", "Only run specified scripts")
+    .option("--only <scripts...>", "Only start specified scripts")
+    .option("--onlyGroup <groups...>", "Only start scripts in specified group")
     .action((pmConfigFilePath, options) => {
         start(pmConfigFilePath, options);
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,14 @@ import { Command } from "commander";
 import { logs, restart, shutdown, start, status } from "./commands";
 
 const program = new Command();
-program.command("start [pmConfigFilePath]").action((pmConfigFilePath) => {
-    start(pmConfigFilePath);
-});
+
+
+program
+    .command("start [pmConfigFilePath]")
+    .option('--only <scripts...>', 'Only run specified scripts')
+    .action((pmConfigFilePath, options) => {
+        start(pmConfigFilePath, options);
+    });
 
 program.command("logs [name]").action((name) => {
     logs(name);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,9 @@ import { logs, restart, shutdown, start, status } from "./commands";
 
 const program = new Command();
 
-
 program
     .command("start [pmConfigFilePath]")
-    .option('--only <scripts...>', 'Only run specified scripts')
+    .option("--only <scripts...>", "Only run specified scripts")
     .action((pmConfigFilePath, options) => {
         start(pmConfigFilePath, options);
     });

--- a/src/script-definition.type.ts
+++ b/src/script-definition.type.ts
@@ -1,4 +1,5 @@
 export interface ScriptDefinition {
     name: string;
     script: string;
+    group: string | string[];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,48 +15,48 @@ __metadata:
   linkType: hard
 
 "@babel/code-frame@npm:^7.0.0":
-  version: 7.16.7
-  resolution: "@babel/code-frame@npm:7.16.7"
+  version: 7.18.6
+  resolution: "@babel/code-frame@npm:7.18.6"
   dependencies:
-    "@babel/highlight": ^7.16.7
-  checksum: db2f7faa31bc2c9cf63197b481b30ea57147a5fc1a6fab60e5d6c02cdfbf6de8e17b5121f99917b3dabb5eeb572da078312e70697415940383efc140d4e0808b
+    "@babel/highlight": ^7.18.6
+  checksum: 195e2be3172d7684bf95cff69ae3b7a15a9841ea9d27d3c843662d50cdd7d6470fd9c8e64be84d031117e4a4083486effba39f9aef6bbb2c89f7f21bcfba33ba
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.16.7":
-  version: 7.16.7
-  resolution: "@babel/helper-validator-identifier@npm:7.16.7"
-  checksum: dbb3db9d184343152520a209b5684f5e0ed416109cde82b428ca9c759c29b10c7450657785a8b5c5256aa74acc6da491c1f0cf6b784939f7931ef82982051b69
+"@babel/helper-validator-identifier@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/helper-validator-identifier@npm:7.18.6"
+  checksum: e295254d616bbe26e48c196a198476ab4d42a73b90478c9842536cf910ead887f5af6b5c4df544d3052a25ccb3614866fa808dc1e3a5a4291acd444e243c0648
   languageName: node
   linkType: hard
 
-"@babel/highlight@npm:^7.16.7":
-  version: 7.17.9
-  resolution: "@babel/highlight@npm:7.17.9"
+"@babel/highlight@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/highlight@npm:7.18.6"
   dependencies:
-    "@babel/helper-validator-identifier": ^7.16.7
+    "@babel/helper-validator-identifier": ^7.18.6
     chalk: ^2.0.0
     js-tokens: ^4.0.0
-  checksum: 7bdf10228f2e4d18f48f114411ed584380d356e7c168d7582c14abd8df9909b2fc09e0a7cd334f47c3eb0bc17e639e0c8d9688c6afd5d09a2bdbf0ac193b11fd
+  checksum: 92d8ee61549de5ff5120e945e774728e5ccd57fd3b2ed6eace020ec744823d4a98e242be1453d21764a30a14769ecd62170fba28539b211799bbaf232bbb2789
   languageName: node
   linkType: hard
 
 "@babel/runtime-corejs3@npm:^7.10.2":
-  version: 7.17.9
-  resolution: "@babel/runtime-corejs3@npm:7.17.9"
+  version: 7.18.9
+  resolution: "@babel/runtime-corejs3@npm:7.18.9"
   dependencies:
     core-js-pure: ^3.20.2
     regenerator-runtime: ^0.13.4
-  checksum: c0893eb1ba4fd8a5a0e43d0fd5c3ad61c020dc5953bb74a76e9e10a0adfde7a5d8fd7e78d59b08dce3a0774948c6c40c81df0fdd0a1130c414fd3535fae365cb
+  checksum: 249158b660ac996fa4f4b0d1ab5810db060af40fac4d0bb5da23f55539a151313ae254aa64afc2ab7000d95167824e21a689f74bc24b36fd0f5ca030d522133d
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.10.0, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.16.3":
-  version: 7.17.9
-  resolution: "@babel/runtime@npm:7.17.9"
+"@babel/runtime@npm:^7.10.0, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/runtime@npm:7.18.9"
   dependencies:
     regenerator-runtime: ^0.13.4
-  checksum: 4d56bdb82890f386d5a57c40ef985a0ed7f0a78f789377a2d0c3e8826819e0f7f16ba0fe906d9b2241c5f7ca56630ef0653f5bb99f03771f7b87ff8af4bf5fe3
+  checksum: 36dd736baba7164e82b3cc9d43e081f0cb2d05ff867ad39cac515d99546cee75b7f782018b02a3dcf5f2ef3d27f319faa68965fdfec49d4912c60c6002353a2e
   languageName: node
   linkType: hard
 
@@ -80,12 +80,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@comet/dev-process-manager@workspace:."
   dependencies:
-    "@comet/eslint-config": ^2.0.1-canary.100.0
+    "@comet/eslint-config": ^3.0.0-canary.344.0
     "@types/node": ^14.0.0
     cli-table3: ^0.6.1
     colors: ^1.4.0
     commander: ^9.0.0
-    eslint: ^8.0.0
+    eslint: ^8.20.0
     husky: ^8.0.0
     lint-staged: ^12.0.0
     prettier: ^2.0.0
@@ -97,9 +97,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@comet/eslint-config@npm:^2.0.1-canary.100.0":
-  version: 2.0.1-canary.100.0
-  resolution: "@comet/eslint-config@npm:2.0.1-canary.100.0"
+"@comet/eslint-config@npm:^3.0.0-canary.344.0":
+  version: 3.0.0-canary.344.0
+  resolution: "@comet/eslint-config@npm:3.0.0-canary.344.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40comet%2Feslint-config%2F-%2Feslint-config-3.0.0-canary.344.0.tgz"
   dependencies:
     "@calm/eslint-plugin-react-intl": ^1.0.0
     "@next/eslint-plugin-next": ^12.0.0
@@ -123,7 +123,7 @@ __metadata:
       optional: true
     next:
       optional: true
-  checksum: 1599e5d20db432555784cc53b651c9fa9db50486f75516ab0cb5df11483bcd2c4b517ce78b73eb75926f1407da49e7db976dddbc63b77ebb61fab31f61ab9f50
+  checksum: bf0ce8a499378125e476006a992138db54472a5966c27a4f55341800e72927e28d06c7cb196965e568e45aa79a4d293a9021f1f829e426556a74074441b63680
   languageName: node
   linkType: hard
 
@@ -157,78 +157,80 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/eslintrc@npm:^1.2.3":
-  version: 1.2.3
-  resolution: "@eslint/eslintrc@npm:1.2.3"
+"@eslint/eslintrc@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@eslint/eslintrc@npm:1.3.0"
   dependencies:
     ajv: ^6.12.4
     debug: ^4.3.2
     espree: ^9.3.2
-    globals: ^13.9.0
+    globals: ^13.15.0
     ignore: ^5.2.0
     import-fresh: ^3.2.1
     js-yaml: ^4.1.0
     minimatch: ^3.1.2
     strip-json-comments: ^3.1.1
-  checksum: 48e7b7ac05cd514eee2ebb1d487600f0dd637ac21f63605e353cff6a08c7223275fe4f571d15ee9deae4e78c53edc73369ffcbed15fba4dfc1806179dbf4dc85
+  checksum: a1e734ad31a8b5328dce9f479f185fd4fc83dd7f06c538e1fa457fd8226b89602a55cc6458cd52b29573b01cdfaf42331be8cfc1fec732570086b591f4ed6515
   languageName: node
   linkType: hard
 
-"@formatjs/ecma402-abstract@npm:1.11.4":
-  version: 1.11.4
-  resolution: "@formatjs/ecma402-abstract@npm:1.11.4"
+"@formatjs/ecma402-abstract@npm:1.11.7":
+  version: 1.11.7
+  resolution: "@formatjs/ecma402-abstract@npm:1.11.7"
   dependencies:
-    "@formatjs/intl-localematcher": 0.2.25
-    tslib: ^2.1.0
-  checksum: 05dbe1c6457acfe9cdc0fc770940260e19fa588be6c655b1ff1697506348dac1eee9b249b64e6544531174d07a5a74a9e75f68430947cfdc074ebe8e3c86f86f
+    "@formatjs/intl-localematcher": 0.2.28
+    tslib: 2.4.0
+  checksum: e01271dd67f82f8a0008172da0ab97afbd955fc124260d226d957cc0153652740f33a1267a7a56fd46878c670caaaf9b84c70e88c39c6c6e719d96b200ad2a40
   languageName: node
   linkType: hard
 
-"@formatjs/icu-messageformat-parser@npm:2.1.0":
-  version: 2.1.0
-  resolution: "@formatjs/icu-messageformat-parser@npm:2.1.0"
+"@formatjs/icu-messageformat-parser@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@formatjs/icu-messageformat-parser@npm:2.1.3"
   dependencies:
-    "@formatjs/ecma402-abstract": 1.11.4
-    "@formatjs/icu-skeleton-parser": 1.3.6
-    tslib: ^2.1.0
-  checksum: 8dab4d102b334dd7ab25b85817b074f1b54845d02f9ef9fa5a1fa6a9723176ad28a59d845fdc0eeedb868b891e61a4c530384b123db29f5b14e1f3f8b207373f
+    "@formatjs/ecma402-abstract": 1.11.7
+    "@formatjs/icu-skeleton-parser": 1.3.9
+    tslib: 2.4.0
+  checksum: b39285756815b984ab5a4ef7c2f3f9e4b621dbf402fad887d52f7a458d1c59e317e3457643407ec153de184ea62df8858c4862945e1d7dea646b2f65616b1215
   languageName: node
   linkType: hard
 
-"@formatjs/icu-skeleton-parser@npm:1.3.6":
-  version: 1.3.6
-  resolution: "@formatjs/icu-skeleton-parser@npm:1.3.6"
+"@formatjs/icu-skeleton-parser@npm:1.3.9":
+  version: 1.3.9
+  resolution: "@formatjs/icu-skeleton-parser@npm:1.3.9"
   dependencies:
-    "@formatjs/ecma402-abstract": 1.11.4
-    tslib: ^2.1.0
-  checksum: cce2d8bea54f0096c557dc03920bfe4785893e60962313fab9eeee41f0b411d38b9d45852882b19f261417d730362c8685bea6ba5ac1e2dee141f030cda624e9
+    "@formatjs/ecma402-abstract": 1.11.7
+    tslib: 2.4.0
+  checksum: c4e43e9ce6f64f3649a1b4791cf2a655af95ff3688133a29776a40e59ef98381faf8646854fc58ea432d7f65d70649c159941f1a24c658c944253d572113b436
   languageName: node
   linkType: hard
 
-"@formatjs/intl-localematcher@npm:0.2.25":
-  version: 0.2.25
-  resolution: "@formatjs/intl-localematcher@npm:0.2.25"
+"@formatjs/intl-localematcher@npm:0.2.28":
+  version: 0.2.28
+  resolution: "@formatjs/intl-localematcher@npm:0.2.28"
   dependencies:
-    tslib: ^2.1.0
-  checksum: ee00ddc23317dc47a58831aaca5112e101d8bb1f38adc0ecfe1a9d7e008d0bb1091519f07e1d7d805b0c1e28f2c3e75f697ae479e22423445814412c7669284c
+    tslib: 2.4.0
+  checksum: 5906c3ff997f57b9e8c968b9d3c4cbd94352b9cda58b338f436855091845cf1f364bd261815cccd67f22faa530834d6cb05a0677a1ee6f457e68847cbab928f4
   languageName: node
   linkType: hard
 
-"@formatjs/ts-transformer@npm:3.9.4":
-  version: 3.9.4
-  resolution: "@formatjs/ts-transformer@npm:3.9.4"
+"@formatjs/ts-transformer@npm:3.9.8":
+  version: 3.9.8
+  resolution: "@formatjs/ts-transformer@npm:3.9.8"
   dependencies:
-    "@formatjs/icu-messageformat-parser": 2.1.0
+    "@formatjs/icu-messageformat-parser": 2.1.3
+    "@types/json-stable-stringify": ^1.0.32
     "@types/node": 14 || 16 || 17
     chalk: ^4.0.0
-    tslib: ^2.1.0
+    json-stable-stringify: ^1.0.1
+    tslib: 2.4.0
     typescript: ^4.5
   peerDependencies:
     ts-jest: 27
   peerDependenciesMeta:
     ts-jest:
       optional: true
-  checksum: fe193921beef7487de78169cecaf28808e8d6b66f59dd98b6c9eb45dcb1b5ee4bcb606a0c6236aeb629feb3116db12e95d06a82bb26cb46116e531279b30abf8
+  checksum: e654733146d6561916c476c087b89d6a8499b7f1a1619bdc2b9427c3497c615ec7bf10b1d83a01380c2068a7b266e21e184cc7b918ec2c2276f136cb76706dc9
   languageName: node
   linkType: hard
 
@@ -277,15 +279,15 @@ __metadata:
   linkType: hard
 
 "@graphql-tools/import@npm:^6.2.6":
-  version: 6.6.14
-  resolution: "@graphql-tools/import@npm:6.6.14"
+  version: 6.7.1
+  resolution: "@graphql-tools/import@npm:6.7.1"
   dependencies:
-    "@graphql-tools/utils": 8.6.10
+    "@graphql-tools/utils": 8.9.0
     resolve-from: 5.0.0
-    tslib: ~2.4.0
+    tslib: ^2.4.0
   peerDependencies:
-    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
-  checksum: a61d38a80f602aa36e97b2e2288517e812208d05c9a469e8923a5ebb10d3ee171d1e81b698c720e7ce996971c5ffb9b694ca1806a960ce3b300d6e9716038d51
+    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+  checksum: 1ba6ff176851eff345ccfd37616bd2d800fba074b88abb9a777b59fe153a1e55f2c24d8c033b141303267212f6a01eb874088e403b7efdf10c01c9ec7833af49
   languageName: node
   linkType: hard
 
@@ -320,7 +322,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-tools/merge@npm:6.0.0 - 6.2.14":
+"@graphql-tools/merge@npm:6.0.0 - 6.2.14, @graphql-tools/merge@npm:^6.2.12":
   version: 6.2.14
   resolution: "@graphql-tools/merge@npm:6.2.14"
   dependencies:
@@ -330,31 +332,6 @@ __metadata:
   peerDependencies:
     graphql: ^14.0.0 || ^15.0.0
   checksum: f5ac009e4d99bb8a3ebc52e56db2fd6e7f2ee892a5e9cee7779de68a7970202b1a1b0d0324df8ca910dcac953e04c05cf914109dcc5681e4fda763b419b363eb
-  languageName: node
-  linkType: hard
-
-"@graphql-tools/merge@npm:8.2.11":
-  version: 8.2.11
-  resolution: "@graphql-tools/merge@npm:8.2.11"
-  dependencies:
-    "@graphql-tools/utils": 8.6.10
-    tslib: ~2.4.0
-  peerDependencies:
-    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
-  checksum: cfc77d6d8bb426a1deb0b7763d58d183827a7f1727d0778c829f0824f2b36192543ef7190a5a5620f9e6e8f5627082688ac243884fcb6c570f664a4016435a16
-  languageName: node
-  linkType: hard
-
-"@graphql-tools/merge@npm:^6.2.12":
-  version: 6.2.17
-  resolution: "@graphql-tools/merge@npm:6.2.17"
-  dependencies:
-    "@graphql-tools/schema": ^8.0.2
-    "@graphql-tools/utils": 8.0.2
-    tslib: ~2.3.0
-  peerDependencies:
-    graphql: ^14.0.0 || ^15.0.0
-  checksum: 8b2547b8f7e704abe2e2526b1560085933ffb1e5c7a0b1674ec1f13e19356fa6d3f8152f33c2272f85bcfe1e680674a591c27aac671606fdc0ba6e0cc8fd4851
   languageName: node
   linkType: hard
 
@@ -368,20 +345,6 @@ __metadata:
   peerDependencies:
     graphql: ^14.0.0 || ^15.0.0
   checksum: 4baf3a39bd33ef33dbc0cfc04fa671718f48f603b5301ec21d5501145fd270a258dd4ea94d49a8062091d6c2ed35727e31a7992c564cbb14bb4d159f7f2d60f8
-  languageName: node
-  linkType: hard
-
-"@graphql-tools/schema@npm:^8.0.2":
-  version: 8.3.11
-  resolution: "@graphql-tools/schema@npm:8.3.11"
-  dependencies:
-    "@graphql-tools/merge": 8.2.11
-    "@graphql-tools/utils": 8.6.10
-    tslib: ~2.4.0
-    value-or-promise: 1.0.11
-  peerDependencies:
-    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
-  checksum: b57e673bacdc25d93bae2bc4378709daeeae9738f51d96194ebe88eabb993dd1c14d85ca3828fcddf8a3937fdddfdcb8f41ff6eced504ebb306350aba2668bed
   languageName: node
   linkType: hard
 
@@ -414,25 +377,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-tools/utils@npm:8.0.2":
-  version: 8.0.2
-  resolution: "@graphql-tools/utils@npm:8.0.2"
+"@graphql-tools/utils@npm:8.9.0":
+  version: 8.9.0
+  resolution: "@graphql-tools/utils@npm:8.9.0"
   dependencies:
-    tslib: ~2.3.0
+    tslib: ^2.4.0
   peerDependencies:
-    graphql: ^14.0.0 || ^15.0.0
-  checksum: c26a7fb4ceb1e845f6f8a4dfbf8f5c014f71a346ccff2568ae49eaf4234d1a3eb754ccf528385754b47dcf63c204b7ad815b96d32c5ba3745a916a2667ad0b13
-  languageName: node
-  linkType: hard
-
-"@graphql-tools/utils@npm:8.6.10":
-  version: 8.6.10
-  resolution: "@graphql-tools/utils@npm:8.6.10"
-  dependencies:
-    tslib: ~2.4.0
-  peerDependencies:
-    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
-  checksum: fd020ef2efe98436e86335af37b9d703b2ca937179ce5d4988853c233824bd69ae01b3e2414586edd132501c042c0c582f63f6e3853ad91a59194483c248f416
+    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+  checksum: 8d1d8a11722e211dc8723cd3fd7a97fa5401ab22146e4240a0f9d45547792476c34814ff914524578beec961db7b0ff23a6ddff8fe059764537e594cff35c906
   languageName: node
   linkType: hard
 
@@ -496,12 +448,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/eslint-plugin-next@npm:12.1.6, @next/eslint-plugin-next@npm:^12.0.0":
-  version: 12.1.6
-  resolution: "@next/eslint-plugin-next@npm:12.1.6"
+"@next/eslint-plugin-next@npm:12.2.3, @next/eslint-plugin-next@npm:^12.0.0":
+  version: 12.2.3
+  resolution: "@next/eslint-plugin-next@npm:12.2.3"
   dependencies:
     glob: 7.1.7
-  checksum: 33dcaf71f299d3c8a0744cad512369f92d7a355f3c0d57f2496e888e4242080c49226ec2c59ba2efac04b3a1df51c36019b853b4177df082ca4621a1713a2229
+  checksum: aba5344c477b1a3d361159bbb46812a470f23d7e2ab3d7892ab372c3caad33e6e9c3c7abce45597571a52680eefc1ef451aecac67f469f2062ed78f37b80a3e8
   languageName: node
   linkType: hard
 
@@ -533,9 +485,9 @@ __metadata:
   linkType: hard
 
 "@rushstack/eslint-patch@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "@rushstack/eslint-patch@npm:1.1.3"
-  checksum: 53752d1e34e45a91b30a016b837c33054fcbd0a295c0312b0812dab78289ea680d7c0c3f19c1f885f49764d416727747133765ff5bfce31a9c4cc93c7a56ebe1
+  version: 1.1.4
+  resolution: "@rushstack/eslint-patch@npm:1.1.4"
+  checksum: 597bc84e2f76c7f5f2bcedd4c4b1dd5d02524167a0f67ac588e8fbbd94666297aaf0e6a53ec46afb95554164fc1169ff782841003280e4bc98e80ab6559412c6
   languageName: node
   linkType: hard
 
@@ -568,19 +520,19 @@ __metadata:
   linkType: hard
 
 "@types/eslint@npm:7 || 8":
-  version: 8.4.2
-  resolution: "@types/eslint@npm:8.4.2"
+  version: 8.4.5
+  resolution: "@types/eslint@npm:8.4.5"
   dependencies:
     "@types/estree": "*"
     "@types/json-schema": "*"
-  checksum: e81268cdeb8d64d84af649344df88f064ece0f05db62072657c976b6162ffe16f94b6480a5367d627c629272c2d86d0ee8c24f7095e98f8e743b16f98500673b
+  checksum: 428b0c971a50adb0d08621e76f21b284580a0052a31341a0e6d553f72b54cd0142d549aa1497c7e3bc56e9f6bcc27286e66e0216e1ba76d1a5ecd2279c40bc8c
   languageName: node
   linkType: hard
 
 "@types/estree@npm:*":
-  version: 0.0.51
-  resolution: "@types/estree@npm:0.0.51"
-  checksum: e56a3bcf759fd9185e992e7fdb3c6a5f81e8ff120e871641607581fb3728d16c811702a7d40fa5f869b7f7b4437ab6a87eb8d98ffafeee51e85bbe955932a189
+  version: 1.0.0
+  resolution: "@types/estree@npm:1.0.0"
+  checksum: 910d97fb7092c6738d30a7430ae4786a38542023c6302b95d46f49420b797f21619cdde11fa92b338366268795884111c2eb10356e4bd2c8ad5b92941e9e6443
   languageName: node
   linkType: hard
 
@@ -591,6 +543,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/json-stable-stringify@npm:^1.0.32":
+  version: 1.0.34
+  resolution: "@types/json-stable-stringify@npm:1.0.34"
+  checksum: 45767ecef0f6aae5680c3be6488d5c493f16046e34f182d7e6a2c69a667aab035799752c6f03017c883b134ad3f80e3f78d7e7da81a9c1f3d01676126baf5d0e
+  languageName: node
+  linkType: hard
+
 "@types/json5@npm:^0.0.29":
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
@@ -598,17 +557,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:14 || 16 || 17":
-  version: 17.0.33
-  resolution: "@types/node@npm:17.0.33"
-  checksum: 6620652cc89ce125e1162e060ec4608c25b3635185e3e5dcaae4ed09e4770dc8bf168ba48bcd7059a1a56087a05000d7ed562e81aea7b6a512e2b13d4409c6b6
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^14.0.0":
-  version: 14.18.18
-  resolution: "@types/node@npm:14.18.18"
-  checksum: a165225cd2603f6e62af8407449e4a4407305e03b41c1adf6b186fdf546e1a03c8214217659b5b36c556947c0c06234993ac880d4db6378136a7a810d47e0742
+"@types/node@npm:*, @types/node@npm:14 || 16 || 17, @types/node@npm:^14.0.0":
+  version: 14.18.22
+  resolution: "@types/node@npm:14.18.22"
+  checksum: 5cec8276b834b8988f0af69655423e816729a5757d2015a3199156bdc98ea55206338fad752b26236c55d431dce24eb973b4f5a8918f8e6b17056ffcc12edc08
   languageName: node
   linkType: hard
 
@@ -629,17 +581,17 @@ __metadata:
   linkType: hard
 
 "@typescript-eslint/eslint-plugin@npm:^5.0.0":
-  version: 5.23.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:5.23.0"
+  version: 5.31.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:5.31.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 5.23.0
-    "@typescript-eslint/type-utils": 5.23.0
-    "@typescript-eslint/utils": 5.23.0
-    debug: ^4.3.2
+    "@typescript-eslint/scope-manager": 5.31.0
+    "@typescript-eslint/type-utils": 5.31.0
+    "@typescript-eslint/utils": 5.31.0
+    debug: ^4.3.4
     functional-red-black-tree: ^1.0.1
-    ignore: ^5.1.8
+    ignore: ^5.2.0
     regexpp: ^3.2.0
-    semver: ^7.3.5
+    semver: ^7.3.7
     tsutils: ^3.21.0
   peerDependencies:
     "@typescript-eslint/parser": ^5.0.0
@@ -647,101 +599,101 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 19ee37c0be172469968f61d156d6ce36a975ab72ccbb8f702eb4573c94d1cf9247ff32352ed85eda5e7b2eaace567d5c66b32846f042f9711349213496ec37d4
+  checksum: a6d007e6cc6c7204b9ce09dd6670a5a29f8b75417a84c8238d1dd7fc3bfa4a7294beb961a0ba76e610b695a0c80edd4186803429e3605a21562c23e47b8efa37
   languageName: node
   linkType: hard
 
 "@typescript-eslint/parser@npm:^5.0.0, @typescript-eslint/parser@npm:^5.21.0":
-  version: 5.23.0
-  resolution: "@typescript-eslint/parser@npm:5.23.0"
+  version: 5.31.0
+  resolution: "@typescript-eslint/parser@npm:5.31.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 5.23.0
-    "@typescript-eslint/types": 5.23.0
-    "@typescript-eslint/typescript-estree": 5.23.0
-    debug: ^4.3.2
+    "@typescript-eslint/scope-manager": 5.31.0
+    "@typescript-eslint/types": 5.31.0
+    "@typescript-eslint/typescript-estree": 5.31.0
+    debug: ^4.3.4
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: b65a732b0be06ac9e4b13df78c466517e33fd382985c5d85b6d51cfa295cdf3351594cc2f95dda41d57abb6115e3b8df815fbbb7793aa0c4eddbac11077b90a8
+  checksum: ae842105ff0e5811d54c9c020ee0568170c13f401de293eb4caa2106f3060558773b496b5647f2b80b2969a2890135c054f50e2443a13c3705d5965aa12896c0
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:5.23.0":
-  version: 5.23.0
-  resolution: "@typescript-eslint/scope-manager@npm:5.23.0"
+"@typescript-eslint/scope-manager@npm:5.31.0":
+  version: 5.31.0
+  resolution: "@typescript-eslint/scope-manager@npm:5.31.0"
   dependencies:
-    "@typescript-eslint/types": 5.23.0
-    "@typescript-eslint/visitor-keys": 5.23.0
-  checksum: cd3dda0b18d6730e34784fc63135fc9fe31673898d3e0868cd765ad78855351f285fe577297193cf179b3ce918c3d44453de85159a925f5c02d12a5626e787d8
+    "@typescript-eslint/types": 5.31.0
+    "@typescript-eslint/visitor-keys": 5.31.0
+  checksum: f771adf54a7cf6387bb201a0d4bef598425818c38832cabbf33c369b3fb650932cbb81a28f198727f3ffae5e21445dde710c41c624bd10b3b7283249333b625b
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:5.23.0":
-  version: 5.23.0
-  resolution: "@typescript-eslint/type-utils@npm:5.23.0"
+"@typescript-eslint/type-utils@npm:5.31.0":
+  version: 5.31.0
+  resolution: "@typescript-eslint/type-utils@npm:5.31.0"
   dependencies:
-    "@typescript-eslint/utils": 5.23.0
-    debug: ^4.3.2
+    "@typescript-eslint/utils": 5.31.0
+    debug: ^4.3.4
     tsutils: ^3.21.0
   peerDependencies:
     eslint: "*"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 88bf7c7a08c11f2a02a05fe331750c569bfc2b4759e0dea6ec72ffd1597624a01100965052a5fede1e3f25ea8ef503bd424e03c9805f0a1af223f28b4fd74946
+  checksum: 1e98a6952207cf7d19cdac375a69bcfed953a29746fa1f2b3c7a8c9376c6984c0bb52506539b76d6a9bebc33966c825f032a27859e545447890562dd3c05ef31
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:5.23.0":
-  version: 5.23.0
-  resolution: "@typescript-eslint/types@npm:5.23.0"
-  checksum: 96ae3e80cfae7b34f2846db692c31fb1804bf9651bce1d29f2eb8ae4c763d22f3283adc02dedeebd7cf70e4d8be54ec7f6ca593e03cdca26c791207e7556c2c1
+"@typescript-eslint/types@npm:5.31.0":
+  version: 5.31.0
+  resolution: "@typescript-eslint/types@npm:5.31.0"
+  checksum: 1c4223a7dcbeb2fb52dc723ac366e2cc75549b21d71f5de8515e86e48d13324e4e136e75804e0f71aff56c9936ef494fa4d1e3eb2f189ed60cf8e2c7401ce372
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:5.23.0, @typescript-eslint/typescript-estree@npm:^5.9.1":
-  version: 5.23.0
-  resolution: "@typescript-eslint/typescript-estree@npm:5.23.0"
+"@typescript-eslint/typescript-estree@npm:5.31.0, @typescript-eslint/typescript-estree@npm:^5.9.1":
+  version: 5.31.0
+  resolution: "@typescript-eslint/typescript-estree@npm:5.31.0"
   dependencies:
-    "@typescript-eslint/types": 5.23.0
-    "@typescript-eslint/visitor-keys": 5.23.0
-    debug: ^4.3.2
-    globby: ^11.0.4
+    "@typescript-eslint/types": 5.31.0
+    "@typescript-eslint/visitor-keys": 5.31.0
+    debug: ^4.3.4
+    globby: ^11.1.0
     is-glob: ^4.0.3
-    semver: ^7.3.5
+    semver: ^7.3.7
     tsutils: ^3.21.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 8d85bb1cd777e93cc7322ae8fea25f9b924def02494cdb8395c1d5d17b5fd3ac9bc969418a1d20a5dc28c2cdd85da20e13527e28b595c06ff6f84cd22a78d73f
+  checksum: 921c502ac4c93df9342d29636b384e154c3ac714e2be0308a4c9d3337d24d8b4721b76cbe700f70c7ceef06b50dfc404e4d4d734e446fe319bac030cb653d7b4
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:5.23.0":
-  version: 5.23.0
-  resolution: "@typescript-eslint/utils@npm:5.23.0"
+"@typescript-eslint/utils@npm:5.31.0":
+  version: 5.31.0
+  resolution: "@typescript-eslint/utils@npm:5.31.0"
   dependencies:
     "@types/json-schema": ^7.0.9
-    "@typescript-eslint/scope-manager": 5.23.0
-    "@typescript-eslint/types": 5.23.0
-    "@typescript-eslint/typescript-estree": 5.23.0
+    "@typescript-eslint/scope-manager": 5.31.0
+    "@typescript-eslint/types": 5.31.0
+    "@typescript-eslint/typescript-estree": 5.31.0
     eslint-scope: ^5.1.1
     eslint-utils: ^3.0.0
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-  checksum: 72207399f29856b601148fe1aff07049021fad8e780ee6e896279d2291806d4608f1c28ddc5c3c5616ce94f25dcbcd26f295669e524fc1c4b4db810569c90f85
+  checksum: 2a4200fd8812f7d7dfbe381d856e97da3606f0c59de78829edd297cc76b4851316bf8362b65e66c7db399e9ea31ec71943626ec12022a552bcb7bb591259ec49
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:5.23.0":
-  version: 5.23.0
-  resolution: "@typescript-eslint/visitor-keys@npm:5.23.0"
+"@typescript-eslint/visitor-keys@npm:5.31.0":
+  version: 5.31.0
+  resolution: "@typescript-eslint/visitor-keys@npm:5.31.0"
   dependencies:
-    "@typescript-eslint/types": 5.23.0
-    eslint-visitor-keys: ^3.0.0
-  checksum: 322e10d52a985e8a90d3612bb9d09a87dc64fc4cb1248484f1a9a7a98f65d3ef65a465ce868773a4939e35fa3b726ad609dac5a168efd7eaca4b06df33e965e3
+    "@typescript-eslint/types": 5.31.0
+    eslint-visitor-keys: ^3.3.0
+  checksum: 24ff3b9037b8fafe4f240b1c8a91981d658cd12a019f7961c9fe2f1d4dc84cf64e4071d865073191181b46652f4bd8f8cfc8e053ed8737ba1b9aede3e3252b3d
   languageName: node
   linkType: hard
 
@@ -887,7 +839,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-includes@npm:^3.1.4":
+"array-includes@npm:^3.1.4, array-includes@npm:^3.1.5":
   version: 3.1.5
   resolution: "array-includes@npm:3.1.5"
   dependencies:
@@ -919,7 +871,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array.prototype.flatmap@npm:^1.2.5":
+"array.prototype.flatmap@npm:^1.3.0":
   version: 1.3.0
   resolution: "array.prototype.flatmap@npm:1.3.0"
   dependencies:
@@ -952,10 +904,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axe-core@npm:^4.3.5":
-  version: 4.4.2
-  resolution: "axe-core@npm:4.4.2"
-  checksum: 93fbb36c5ac8ab5e67e49678a6f7be0dc799a9f560edd95cca1f0a8183def8c50205972366b9941a3ea2b20224a1fe230e6d87ef38cb6db70472ed1b694febd1
+"axe-core@npm:^4.4.3":
+  version: 4.4.3
+  resolution: "axe-core@npm:4.4.3"
+  checksum: c3ea000d9ace3ba0bc747c8feafc24b0de62a0f7d93021d0f77b19c73fca15341843510f6170da563d51535d6cfb7a46c5fc0ea36170549dbb44b170208450a2
   languageName: node
   linkType: hard
 
@@ -1166,9 +1118,9 @@ __metadata:
   linkType: hard
 
 "colorette@npm:^2.0.16":
-  version: 2.0.16
-  resolution: "colorette@npm:2.0.16"
-  checksum: cd55596a3a2d1071c1a28eee7fd8a5387593ff1bd10a3e8d0a6221499311fe34a9f2b9272d77c391e0e003dcdc8934fb2f8d106e7ef1f7516f8060c901d41a27
+  version: 2.0.19
+  resolution: "colorette@npm:2.0.19"
+  checksum: 888cf5493f781e5fcf54ce4d49e9d7d698f96ea2b2ef67906834bb319a392c667f9ec69f4a10e268d2946d13a9503d2d19b3abaaaf174e3451bfe91fb9d82427
   languageName: node
   linkType: hard
 
@@ -1188,17 +1140,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^8.3.0":
-  version: 8.3.0
-  resolution: "commander@npm:8.3.0"
-  checksum: 0f82321821fc27b83bd409510bb9deeebcfa799ff0bf5d102128b500b7af22872c0c92cb6a0ebc5a4cf19c6b550fba9cedfa7329d18c6442a625f851377bacf0
-  languageName: node
-  linkType: hard
-
-"commander@npm:^9.0.0":
-  version: 9.2.0
-  resolution: "commander@npm:9.2.0"
-  checksum: 7c82e4cd969712aa6d7c055b8351807a7230f9f31ef7ec7881e11a1147511de85adf5d6ccfd200240a118eecf693b220caf6865b8efbcea558a70d35aa9ed711
+"commander@npm:^9.0.0, commander@npm:^9.3.0":
+  version: 9.4.0
+  resolution: "commander@npm:9.4.0"
+  checksum: a322de584a6ccd1ea83c24f6a660e52d16ffbe2613fcfbb8d2cc68bc9dec637492456d754fe8bb5b039ad843ed8e04fb0b107e581a75f62cde9e1a0ab1546e09
   languageName: node
   linkType: hard
 
@@ -1210,9 +1155,9 @@ __metadata:
   linkType: hard
 
 "core-js-pure@npm:^3.20.2":
-  version: 3.22.5
-  resolution: "core-js-pure@npm:3.22.5"
-  checksum: 923c7391f20dcd6fae861a2c9cb92caa0158b9d65fd8ff24eb273814cdf84df4b409fe4cf2c3fcff609daa1a408c64ba752c28f030d8bc31ac1128de8616ad1a
+  version: 3.24.0
+  resolution: "core-js-pure@npm:3.24.0"
+  checksum: 9ed3ec22e3c428ef346ab4a8f25fffe7938734513fbe738d4b46cc59735a2b98319ffd2f65e3e29fe5f1df5963faeb22e518d2576bf93efa02f49ef0f4d1a0ce
   languageName: node
   linkType: hard
 
@@ -1275,7 +1220,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"damerau-levenshtein@npm:^1.0.7":
+"damerau-levenshtein@npm:^1.0.8":
   version: 1.0.8
   resolution: "damerau-levenshtein@npm:1.0.8"
   checksum: d240b7757544460ae0586a341a53110ab0a61126570ef2d8c731e3eab3f0cb6e488e2609e6a69b46727635de49be20b071688698744417ff1b6c1d7ccd03e0de
@@ -1307,7 +1252,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.1.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4":
+"debug@npm:^4.1.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:
@@ -1487,10 +1432,10 @@ __metadata:
   linkType: hard
 
 "eslint-config-next@npm:^12.0.0":
-  version: 12.1.6
-  resolution: "eslint-config-next@npm:12.1.6"
+  version: 12.2.3
+  resolution: "eslint-config-next@npm:12.2.3"
   dependencies:
-    "@next/eslint-plugin-next": 12.1.6
+    "@next/eslint-plugin-next": 12.2.3
     "@rushstack/eslint-patch": ^1.1.3
     "@typescript-eslint/parser": ^5.21.0
     eslint-import-resolver-node: ^0.3.6
@@ -1501,12 +1446,11 @@ __metadata:
     eslint-plugin-react-hooks: ^4.5.0
   peerDependencies:
     eslint: ^7.23.0 || ^8.0.0
-    next: ">=10.2.0"
     typescript: ">=3.3.1"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: b3ba9e8f598b4018002aaaa64dc0e8a8b5994be992839a8b1b0a7f7ab0e4cbe006a30fd787524baab7c1e979dc6b41d4cdcbe239be181635413d987be7f25b6f
+  checksum: bba70ac3186f1ee4df5479857397c69393e3fa38649e1bf51e390ec53193751fdf0da712e70de861d58ea5029288b7a78c35d08a49a48ac3ccd5ce5598073c2b
   languageName: node
   linkType: hard
 
@@ -1558,19 +1502,19 @@ __metadata:
   linkType: hard
 
 "eslint-plugin-formatjs@npm:^3.0.0":
-  version: 3.1.1
-  resolution: "eslint-plugin-formatjs@npm:3.1.1"
+  version: 3.1.5
+  resolution: "eslint-plugin-formatjs@npm:3.1.5"
   dependencies:
-    "@formatjs/icu-messageformat-parser": 2.1.0
-    "@formatjs/ts-transformer": 3.9.4
+    "@formatjs/icu-messageformat-parser": 2.1.3
+    "@formatjs/ts-transformer": 3.9.8
     "@types/eslint": 7 || 8
     "@typescript-eslint/typescript-estree": ^5.9.1
     emoji-regex: ^10.0.0
-    tslib: ^2.1.0
+    tslib: 2.4.0
     typescript: ^4.5
   peerDependencies:
     eslint: 7 || 8
-  checksum: 84d7c51493fc69712595efef562fa3b5cf85a407b84cc78dc273b2b9c7809dc4a7025e7af1c6b4837b5df60559af8ff0c0648d8860629db3c20c2bf31ed8f704
+  checksum: 466365c709576b2409f164398fb7245daf1c6b4849b856f679402280d9c855d4e0c5b0af9e0ac0c5e4e45903acf019258fa8204051251e2c4faec28f73611d12
   languageName: node
   linkType: hard
 
@@ -1612,30 +1556,31 @@ __metadata:
   linkType: hard
 
 "eslint-plugin-jsx-a11y@npm:^6.5.1":
-  version: 6.5.1
-  resolution: "eslint-plugin-jsx-a11y@npm:6.5.1"
+  version: 6.6.1
+  resolution: "eslint-plugin-jsx-a11y@npm:6.6.1"
   dependencies:
-    "@babel/runtime": ^7.16.3
+    "@babel/runtime": ^7.18.9
     aria-query: ^4.2.2
-    array-includes: ^3.1.4
+    array-includes: ^3.1.5
     ast-types-flow: ^0.0.7
-    axe-core: ^4.3.5
+    axe-core: ^4.4.3
     axobject-query: ^2.2.0
-    damerau-levenshtein: ^1.0.7
+    damerau-levenshtein: ^1.0.8
     emoji-regex: ^9.2.2
     has: ^1.0.3
-    jsx-ast-utils: ^3.2.1
+    jsx-ast-utils: ^3.3.2
     language-tags: ^1.0.5
-    minimatch: ^3.0.4
+    minimatch: ^3.1.2
+    semver: ^6.3.0
   peerDependencies:
     eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-  checksum: 311ab993ed982d0cc7cb0ba02fbc4b36c4a94e9434f31e97f13c4d67e8ecb8aec36baecfd759ff70498846e7e11d7a197eb04c39ad64934baf3354712fd0bc9d
+  checksum: baae7377f0e25a0cc9b34dc333a3dc6ead9ee8365e445451eff554c3ca267a0a6cb88127fe90395c578ab1b92cfed246aef7dc8d2b48b603389e10181799e144
   languageName: node
   linkType: hard
 
 "eslint-plugin-prettier@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "eslint-plugin-prettier@npm:4.0.0"
+  version: 4.2.1
+  resolution: "eslint-plugin-prettier@npm:4.2.1"
   dependencies:
     prettier-linter-helpers: ^1.0.0
   peerDependencies:
@@ -1644,40 +1589,40 @@ __metadata:
   peerDependenciesMeta:
     eslint-config-prettier:
       optional: true
-  checksum: 03d69177a3c21fa2229c7e427ce604429f0b20ab7f411e2e824912f572a207c7f5a41fd1f0a95b9b8afe121e291c1b1f1dc1d44c7aad4b0837487f9c19f5210d
+  checksum: b9e839d2334ad8ec7a5589c5cb0f219bded260839a857d7a486997f9870e95106aa59b8756ff3f37202085ebab658de382b0267cae44c3a7f0eb0bcc03a4f6d6
   languageName: node
   linkType: hard
 
 "eslint-plugin-react-hooks@npm:^4.0.0, eslint-plugin-react-hooks@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "eslint-plugin-react-hooks@npm:4.5.0"
+  version: 4.6.0
+  resolution: "eslint-plugin-react-hooks@npm:4.6.0"
   peerDependencies:
     eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
-  checksum: 0389377de635dd9b769f6f52e2c9e6ab857a0cdfecc3734c95ce81676a752e781bb5c44fd180e01953a03a77278323d90729776438815557b069ceb988ab1f9f
+  checksum: 23001801f14c1d16bf0a837ca7970d9dd94e7b560384b41db378b49b6e32dc43d6e2790de1bd737a652a86f81a08d6a91f402525061b47719328f586a57e86c3
   languageName: node
   linkType: hard
 
 "eslint-plugin-react@npm:^7.0.0, eslint-plugin-react@npm:^7.29.4":
-  version: 7.29.4
-  resolution: "eslint-plugin-react@npm:7.29.4"
+  version: 7.30.1
+  resolution: "eslint-plugin-react@npm:7.30.1"
   dependencies:
-    array-includes: ^3.1.4
-    array.prototype.flatmap: ^1.2.5
+    array-includes: ^3.1.5
+    array.prototype.flatmap: ^1.3.0
     doctrine: ^2.1.0
     estraverse: ^5.3.0
     jsx-ast-utils: ^2.4.1 || ^3.0.0
     minimatch: ^3.1.2
     object.entries: ^1.1.5
     object.fromentries: ^2.0.5
-    object.hasown: ^1.1.0
+    object.hasown: ^1.1.1
     object.values: ^1.1.5
     prop-types: ^15.8.1
     resolve: ^2.0.0-next.3
     semver: ^6.3.0
-    string.prototype.matchall: ^4.0.6
+    string.prototype.matchall: ^4.0.7
   peerDependencies:
     eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-  checksum: bb7d3715ccd7f3e0d7bfaa2125b26d96865695bcfea4a3d510a5763342a74ab5b99a88e13aad9245f9461ad87e4bce69c33fc946888115d576233f9b6e69700d
+  checksum: 553fb9ece6beb7c14cf6f84670c786c8ac978c2918421994dcc4edd2385302022e5d5ac4a39fafdb35954e29cecddefed61758040c3c530cafcf651f674a9d51
   languageName: node
   linkType: hard
 
@@ -1750,18 +1695,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^3.0.0, eslint-visitor-keys@npm:^3.3.0":
+"eslint-visitor-keys@npm:^3.3.0":
   version: 3.3.0
   resolution: "eslint-visitor-keys@npm:3.3.0"
   checksum: d59e68a7c5a6d0146526b0eec16ce87fbf97fe46b8281e0d41384224375c4e52f5ffb9e16d48f4ea50785cde93f766b0c898e31ab89978d88b0e1720fbfb7808
   languageName: node
   linkType: hard
 
-"eslint@npm:^8.0.0":
-  version: 8.15.0
-  resolution: "eslint@npm:8.15.0"
+"eslint@npm:^8.20.0":
+  version: 8.20.0
+  resolution: "eslint@npm:8.20.0"
   dependencies:
-    "@eslint/eslintrc": ^1.2.3
+    "@eslint/eslintrc": ^1.3.0
     "@humanwhocodes/config-array": ^0.9.2
     ajv: ^6.10.0
     chalk: ^4.0.0
@@ -1779,7 +1724,7 @@ __metadata:
     file-entry-cache: ^6.0.1
     functional-red-black-tree: ^1.0.1
     glob-parent: ^6.0.1
-    globals: ^13.6.0
+    globals: ^13.15.0
     ignore: ^5.2.0
     import-fresh: ^3.0.0
     imurmurhash: ^0.1.4
@@ -1798,7 +1743,7 @@ __metadata:
     v8-compile-cache: ^2.0.3
   bin:
     eslint: bin/eslint.js
-  checksum: d8896393832e154e1381a21041cfe4d12a73a76fac26ea27cabbc0e5fdac87918ad651f07f804ef6faacd3868572de3c1ec5d96edf5502bc999eff0c423638f7
+  checksum: a31adf390d71d916925586bc8467b48f620e93dd0416bc1e897d99265af88b48d4eba3985b5ff4653ae5cc46311a360d373574002277e159bb38a4363abf9228
   languageName: node
   linkType: hard
 
@@ -2003,9 +1948,9 @@ __metadata:
   linkType: hard
 
 "flatted@npm:^3.1.0":
-  version: 3.2.5
-  resolution: "flatted@npm:3.2.5"
-  checksum: 3c436e9695ccca29620b4be5671dd72e5dd0a7500e0856611b7ca9bd8169f177f408c3b9abfa78dfe1493ee2d873e2c119080a8a9bee4e1a186a9e60ca6c89f1
+  version: 3.2.6
+  resolution: "flatted@npm:3.2.6"
+  checksum: 33b87aa88dfa40ca6ee31d7df61712bbbad3d3c05c132c23e59b9b61d34631b337a18ff2b8dc5553acdc871ec72b741e485f78969cf006124a3f57174de29a0e
   languageName: node
   linkType: hard
 
@@ -2128,25 +2073,25 @@ __metadata:
   linkType: hard
 
 "glob@npm:^7.1.3, glob@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "glob@npm:7.2.0"
+  version: 7.2.3
+  resolution: "glob@npm:7.2.3"
   dependencies:
     fs.realpath: ^1.0.0
     inflight: ^1.0.4
     inherits: 2
-    minimatch: ^3.0.4
+    minimatch: ^3.1.1
     once: ^1.3.0
     path-is-absolute: ^1.0.0
-  checksum: 78a8ea942331f08ed2e055cb5b9e40fe6f46f579d7fd3d694f3412fe5db23223d29b7fee1575440202e9a7ff9a72ab106a39fee39934c7bedafe5e5f8ae20134
+  checksum: 29452e97b38fa704dabb1d1045350fb2467cf0277e155aa9ff7077e90ad81d1ea9d53d3ee63bd37c05b09a065e90f16aec4a65f5b8de401d1dac40bc5605d133
   languageName: node
   linkType: hard
 
-"globals@npm:^13.6.0, globals@npm:^13.9.0":
-  version: 13.15.0
-  resolution: "globals@npm:13.15.0"
+"globals@npm:^13.15.0":
+  version: 13.17.0
+  resolution: "globals@npm:13.17.0"
   dependencies:
     type-fest: ^0.20.2
-  checksum: 383ade0873b2ab29ce6d143466c203ed960491575bc97406395e5c8434026fb02472ab2dfff5bc16689b8460269b18fda1047975295cd0183904385c51258bae
+  checksum: fbaf4112e59b92c9f5575e85ce65e9e17c0b82711196ec5f58beb08599bbd92fd72703d6dfc9b080381fd35b644e1b11dcf25b38cc2341ec21df942594cbc8ce
   languageName: node
   linkType: hard
 
@@ -2164,7 +2109,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.0.4":
+"globby@npm:^11.1.0":
   version: 11.1.0
   resolution: "globby@npm:11.1.0"
   dependencies:
@@ -2309,7 +2254,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.1.4, ignore@npm:^5.1.8, ignore@npm:^5.2.0":
+"ignore@npm:^5.1.4, ignore@npm:^5.2.0":
   version: 5.2.0
   resolution: "ignore@npm:5.2.0"
   checksum: 6b1f926792d614f64c6c83da3a1f9c83f6196c2839aa41e1e32dd7b8d174cef2e329d75caabb62cb61ce9dc432f75e67d07d122a037312db7caa73166a1bdb77
@@ -2410,7 +2355,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.2.0, is-core-module@npm:^2.8.1":
+"is-core-module@npm:^2.8.1, is-core-module@npm:^2.9.0":
   version: 2.9.0
   resolution: "is-core-module@npm:2.9.0"
   dependencies:
@@ -2619,6 +2564,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-stable-stringify@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "json-stable-stringify@npm:1.0.1"
+  dependencies:
+    jsonify: ~0.0.0
+  checksum: 65d6cbf0fca72a4136999f65f4401cf39a129f7aeff0fdd987ac3d3423a2113659294045fb8377e6e20d865cac32b1b8d70f3d87346c9786adcee60661d96ca5
+  languageName: node
+  linkType: hard
+
 "json5@npm:^1.0.1":
   version: 1.0.1
   resolution: "json5@npm:1.0.1"
@@ -2630,20 +2584,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsx-ast-utils@npm:^2.4.1 || ^3.0.0, jsx-ast-utils@npm:^3.2.1":
-  version: 3.3.0
-  resolution: "jsx-ast-utils@npm:3.3.0"
+"jsonify@npm:~0.0.0":
+  version: 0.0.0
+  resolution: "jsonify@npm:0.0.0"
+  checksum: d8d4ed476c116e6987a460dcb82f22284686caae9f498ac87b0502c1765ac1522f4f450a4cad4cc368d202fd3b27a3860735140a82867fc6d558f5f199c38bce
+  languageName: node
+  linkType: hard
+
+"jsx-ast-utils@npm:^2.4.1 || ^3.0.0, jsx-ast-utils@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "jsx-ast-utils@npm:3.3.2"
   dependencies:
-    array-includes: ^3.1.4
+    array-includes: ^3.1.5
     object.assign: ^4.1.2
-  checksum: e3c0667e8979c70600fb0456b19f0ec194994c953678ac2772a819d8d5740df2ed751e49e4f1db7869bf63251585a93b18acd42ef02269fe41cb23941d0d4950
+  checksum: 61d4596d44480afc03ae0a7ebb272aa6603dc4c3645805dea0fc8d9f0693542cd0959f3ba7c0c9b16c13dd5a900c7c4310108bada273132a8355efe3fed22064
   languageName: node
   linkType: hard
 
 "language-subtag-registry@npm:~0.3.2":
-  version: 0.3.21
-  resolution: "language-subtag-registry@npm:0.3.21"
-  checksum: 5f794525a5bfcefeea155a681af1c03365b60e115b688952a53c6e0b9532b09163f57f1fcb69d6150e0e805ec0350644a4cb35da98f4902562915be9f89572a1
+  version: 0.3.22
+  resolution: "language-subtag-registry@npm:0.3.22"
+  checksum: 8ab70a7e0e055fe977ac16ea4c261faec7205ac43db5e806f72e5b59606939a3b972c4bd1e10e323b35d6ffa97c3e1c4c99f6553069dad2dfdd22020fa3eb56a
   languageName: node
   linkType: hard
 
@@ -2666,10 +2627,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lilconfig@npm:2.0.4":
-  version: 2.0.4
-  resolution: "lilconfig@npm:2.0.4"
-  checksum: 02ae530aa49218d782eb79e92c600ea5220828987f85aa3403fa512cadc7efe38c0ac7d0cd2edf600ad3fae1f6c1752f5b4bb78c0d9950435b044d53d507c9e1
+"lilconfig@npm:2.0.5":
+  version: 2.0.5
+  resolution: "lilconfig@npm:2.0.5"
+  checksum: f7bb9e42656f06930ad04e583026f087508ae408d3526b8b54895e934eb2a966b7aafae569656f2c79a29fe6d779b3ec44ba577e80814734c8655d6f71cdf2d1
   languageName: node
   linkType: hard
 
@@ -2681,30 +2642,30 @@ __metadata:
   linkType: hard
 
 "lint-staged@npm:^12.0.0":
-  version: 12.4.1
-  resolution: "lint-staged@npm:12.4.1"
+  version: 12.5.0
+  resolution: "lint-staged@npm:12.5.0"
   dependencies:
     cli-truncate: ^3.1.0
     colorette: ^2.0.16
-    commander: ^8.3.0
-    debug: ^4.3.3
+    commander: ^9.3.0
+    debug: ^4.3.4
     execa: ^5.1.1
-    lilconfig: 2.0.4
-    listr2: ^4.0.1
-    micromatch: ^4.0.4
+    lilconfig: 2.0.5
+    listr2: ^4.0.5
+    micromatch: ^4.0.5
     normalize-path: ^3.0.0
-    object-inspect: ^1.12.0
+    object-inspect: ^1.12.2
     pidtree: ^0.5.0
     string-argv: ^0.3.1
-    supports-color: ^9.2.1
+    supports-color: ^9.2.2
     yaml: ^1.10.2
   bin:
     lint-staged: bin/lint-staged.js
-  checksum: b57183b537064cda6caef6679918bf271903145f7c28d09567e918b8b13094048b579f8df808ea590dbd7ea2ec332327c5e372cf3d77e85b7b0254f6541ce4c3
+  checksum: ac203917be098305bc0aebd5f1a969e88ea0854e8fb2199ebcbbb059d8bce324cf97db8f3d25f7954dd48c0666ae13987fb4db569d5b6fecda06f9fb742278e1
   languageName: node
   linkType: hard
 
-"listr2@npm:^4.0.1":
+"listr2@npm:^4.0.5":
   version: 4.0.5
   resolution: "listr2@npm:4.0.5"
   dependencies:
@@ -2874,7 +2835,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.4":
+"micromatch@npm:^4.0.4, micromatch@npm:^4.0.5":
   version: 4.0.5
   resolution: "micromatch@npm:4.0.5"
   dependencies:
@@ -2916,7 +2877,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.0.2, minimatch@npm:^3.0.4, minimatch@npm:^3.1.2":
+"minimatch@npm:^3.0.2, minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
@@ -2939,17 +2900,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:2.1.2":
+"ms@npm:2.1.2, ms@npm:^2.1.1":
   version: 2.1.2
   resolution: "ms@npm:2.1.2"
   checksum: 673cdb2c3133eb050c745908d8ce632ed2c02d85640e2edb3ace856a2266a813b30c613569bf3354fdf4ea7d1a1494add3bfa95e2713baa27d0c2c71fc44f58f
-  languageName: node
-  linkType: hard
-
-"ms@npm:^2.1.1":
-  version: 2.1.3
-  resolution: "ms@npm:2.1.3"
-  checksum: aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
   languageName: node
   linkType: hard
 
@@ -2970,24 +2924,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:2.6.1":
+"node-fetch@npm:2.6.1, node-fetch@npm:^2.6.1":
   version: 2.6.1
   resolution: "node-fetch@npm:2.6.1"
   checksum: 91075bedd57879117e310fbcc36983ad5d699e522edb1ebcdc4ee5294c982843982652925c3532729fdc86b2d64a8a827797a745f332040d91823c8752ee4d7c
-  languageName: node
-  linkType: hard
-
-"node-fetch@npm:^2.6.1":
-  version: 2.6.7
-  resolution: "node-fetch@npm:2.6.7"
-  dependencies:
-    whatwg-url: ^5.0.0
-  peerDependencies:
-    encoding: ^0.1.0
-  peerDependenciesMeta:
-    encoding:
-      optional: true
-  checksum: 8d816ffd1ee22cab8301c7756ef04f3437f18dace86a1dae22cf81db8ef29c0bf6655f3215cb0cdb22b420b6fe141e64b26905e7f33f9377a7fa59135ea3e10b
   languageName: node
   linkType: hard
 
@@ -3035,10 +2975,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-inspect@npm:^1.12.0, object-inspect@npm:^1.9.0":
-  version: 1.12.0
-  resolution: "object-inspect@npm:1.12.0"
-  checksum: 2b36d4001a9c921c6b342e2965734519c9c58c355822243c3207fbf0aac271f8d44d30d2d570d450b2cc6f0f00b72bcdba515c37827d2560e5f22b1899a31cf4
+"object-inspect@npm:^1.12.0, object-inspect@npm:^1.12.2, object-inspect@npm:^1.9.0":
+  version: 1.12.2
+  resolution: "object-inspect@npm:1.12.2"
+  checksum: a534fc1b8534284ed71f25ce3a496013b7ea030f3d1b77118f6b7b1713829262be9e6243acbcb3ef8c626e2b64186112cb7f6db74e37b2789b9c789ca23048b2
   languageName: node
   linkType: hard
 
@@ -3083,7 +3023,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.hasown@npm:^1.1.0":
+"object.hasown@npm:^1.1.1":
   version: 1.1.1
   resolution: "object.hasown@npm:1.1.1"
   dependencies:
@@ -3249,7 +3189,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-parse@npm:^1.0.6, path-parse@npm:^1.0.7":
+"path-parse@npm:^1.0.7":
   version: 1.0.7
   resolution: "path-parse@npm:1.0.7"
   checksum: 49abf3d81115642938a8700ec580da6e830dde670be21893c62f4e10bd7dd4c3742ddc603fe24f898cba7eb0c6bc1777f8d9ac14185d34540c6d4d80cd9cae8a
@@ -3485,12 +3425,15 @@ __metadata:
   linkType: hard
 
 "resolve@npm:^2.0.0-next.3":
-  version: 2.0.0-next.3
-  resolution: "resolve@npm:2.0.0-next.3"
+  version: 2.0.0-next.4
+  resolution: "resolve@npm:2.0.0-next.4"
   dependencies:
-    is-core-module: ^2.2.0
-    path-parse: ^1.0.6
-  checksum: f34b3b93ada77d64a6d590c06a83e198f3a827624c4ec972260905fa6c4d612164fbf0200d16d2beefea4ad1755b001f4a9a1293d8fc2322a8f7d6bf692c4ff5
+    is-core-module: ^2.9.0
+    path-parse: ^1.0.7
+    supports-preserve-symlinks-flag: ^1.0.0
+  bin:
+    resolve: bin/resolve
+  checksum: c438ac9a650f2030fd074219d7f12ceb983b475da2d89ad3d6dd05fbf6b7a0a8cd37d4d10b43cb1f632bc19f22246ab7f36ebda54d84a29bfb2910a0680906d3
   languageName: node
   linkType: hard
 
@@ -3508,12 +3451,15 @@ __metadata:
   linkType: hard
 
 "resolve@patch:resolve@^2.0.0-next.3#~builtin<compat/resolve>":
-  version: 2.0.0-next.3
-  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.3#~builtin<compat/resolve>::version=2.0.0-next.3&hash=07638b"
+  version: 2.0.0-next.4
+  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.4#~builtin<compat/resolve>::version=2.0.0-next.4&hash=07638b"
   dependencies:
-    is-core-module: ^2.2.0
-    path-parse: ^1.0.6
-  checksum: 21684b4d99a4877337cdbd5484311c811b3e8910edb5d868eec85c6e6550b0f570d911f9a384f9e176172d6713f2715bd0b0887fa512cb8c6aeece018de6a9f8
+    is-core-module: ^2.9.0
+    path-parse: ^1.0.7
+    supports-preserve-symlinks-flag: ^1.0.0
+  bin:
+    resolve: bin/resolve
+  checksum: 4bf9f4f8a458607af90518ff73c67a4bc1a38b5a23fef2bb0ccbd45e8be89820a1639b637b0ba377eb2be9eedfb1739a84cde24fe4cd670c8207d8fea922b011
   languageName: node
   linkType: hard
 
@@ -3562,11 +3508,11 @@ __metadata:
   linkType: hard
 
 "rxjs@npm:^7.5.5":
-  version: 7.5.5
-  resolution: "rxjs@npm:7.5.5"
+  version: 7.5.6
+  resolution: "rxjs@npm:7.5.6"
   dependencies:
     tslib: ^2.1.0
-  checksum: e034f60805210cce756dd2f49664a8108780b117cf5d0e2281506e9e6387f7b4f1532d974a8c8b09314fa7a16dd2f6cff3462072a5789672b5dcb45c4173f3c6
+  checksum: fc05f01364a74dac57490fb3e07ea63b422af04017fae1db641a009073f902ef69f285c5daac31359620dc8d9aee7d81e42b370ca2a8573d1feae0b04329383b
   languageName: node
   linkType: hard
 
@@ -3588,7 +3534,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5":
+"semver@npm:^7.3.7":
   version: 7.3.7
   resolution: "semver@npm:7.3.7"
   dependencies:
@@ -3784,7 +3730,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string.prototype.matchall@npm:^4.0.6":
+"string.prototype.matchall@npm:^4.0.7":
   version: 4.0.7
   resolution: "string.prototype.matchall@npm:4.0.7"
   dependencies:
@@ -3930,7 +3876,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^9.2.1":
+"supports-color@npm:^9.2.2":
   version: 9.2.2
   resolution: "supports-color@npm:9.2.2"
   checksum: 976d84877402fc38c1d43b1fde20b0a8dc0283273f21cfebe4ff7507d27543cdfbeec7db108a96b82d694465f06d64e8577562b05d0520b41710088e0a33cc50
@@ -3981,13 +3927,6 @@ __metadata:
   dependencies:
     is-number: ^7.0.0
   checksum: f76fa01b3d5be85db6a2a143e24df9f60dd047d151062d0ba3df62953f2f697b16fe5dad9b0ac6191c7efc7b1d9dcaa4b768174b7b29da89d4428e64bc0a20ed
-  languageName: node
-  linkType: hard
-
-"tr46@npm:~0.0.3":
-  version: 0.0.3
-  resolution: "tr46@npm:0.0.3"
-  checksum: 726321c5eaf41b5002e17ffbd1fb7245999a073e8979085dacd47c4b4e8068ff5777142fc6726d6ca1fd2ff16921b48788b87225cbc57c72636f6efa8efbffe3
   languageName: node
   linkType: hard
 
@@ -4062,17 +4001,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:2.4.0, tslib@npm:^2, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "tslib@npm:2.4.0"
+  checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
+  languageName: node
+  linkType: hard
+
 "tslib@npm:^1.8.1":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:~2.4.0":
-  version: 2.4.0
-  resolution: "tslib@npm:2.4.0"
-  checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
   languageName: node
   linkType: hard
 
@@ -4094,13 +4033,6 @@ __metadata:
   version: 2.2.0
   resolution: "tslib@npm:2.2.0"
   checksum: a48c9639f7496fa701ea8ffe0561070fcb44c104a59632f7f845c0af00825c99b6373575ec59b2b5cdbfd7505875086dbe5dc83312304d8979f22ce571218ca3
-  languageName: node
-  linkType: hard
-
-"tslib@npm:~2.3.0":
-  version: 2.3.1
-  resolution: "tslib@npm:2.3.1"
-  checksum: de17a98d4614481f7fcb5cd53ffc1aaf8654313be0291e1bfaee4b4bb31a20494b7d218ff2e15017883e8ea9626599b3b0e0229c18383ba9dce89da2adf15cb9
   languageName: node
   linkType: hard
 
@@ -4219,34 +4151,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"value-or-promise@npm:1.0.11":
-  version: 1.0.11
-  resolution: "value-or-promise@npm:1.0.11"
-  checksum: 13f8f2ef620118c73b4d1beee8ce6045d7182bbf15090ecfbcafb677ec43698506a5e9ace6bea5ea35c32bc612c9b1f824bb59b6581cdfb5c919052745c277d5
-  languageName: node
-  linkType: hard
-
 "value-or-promise@npm:1.0.6":
   version: 1.0.6
   resolution: "value-or-promise@npm:1.0.6"
   checksum: 3f255d288ba25c4021cb88f319c3a8fe147d1cbc9a4a3b70c795c1a6225d126959b1709d3b4d357745ceb4812f644218de02907ad4934023ca0be2db7e194f86
-  languageName: node
-  linkType: hard
-
-"webidl-conversions@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "webidl-conversions@npm:3.0.1"
-  checksum: c92a0a6ab95314bde9c32e1d0a6dfac83b578f8fa5f21e675bc2706ed6981bc26b7eb7e6a1fab158e5ce4adf9caa4a0aee49a52505d4d13c7be545f15021b17c
-  languageName: node
-  linkType: hard
-
-"whatwg-url@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "whatwg-url@npm:5.0.0"
-  dependencies:
-    tr46: ~0.0.3
-    webidl-conversions: ^3.0.0
-  checksum: b8daed4ad3356cc4899048a15b2c143a9aed0dfae1f611ebd55073310c7b910f522ad75d727346ad64203d7e6c79ef25eafd465f4d12775ca44b90fa82ed9e2c
   languageName: node
   linkType: hard
 
@@ -4321,7 +4229,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:7.4.5":
+"ws@npm:7.4.5, ws@npm:^5.2.0 || ^6.0.0 || ^7.0.0":
   version: 7.4.5
   resolution: "ws@npm:7.4.5"
   peerDependencies:
@@ -4333,21 +4241,6 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 5c7d1527f93ef27f9306aaf52db76315e8ff84174d1df717196527c50334c80bc10307dcaf6674a9aca4bb73aac3f77c23d3d9b1800e8aa810a5ee7f52d67cfb
-  languageName: node
-  linkType: hard
-
-"ws@npm:^5.2.0 || ^6.0.0 || ^7.0.0":
-  version: 7.5.7
-  resolution: "ws@npm:7.5.7"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ^5.0.2
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 5c1f669a166fb57560b4e07f201375137fa31d9186afde78b1508926345ce546332f109081574ddc4e38cc474c5406b5fc71c18d71eb75f6e2d2245576976cba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
depends on #19 

start now also connects to the deamon

this allows multiple calls to start that start different scripts

start-daemon is started as background process in start (if not yet running)

Major (incompatible) changes:
- start is not blocking anymore (and doesn't show logs anymore)
- changing pm config file isn't possible anymore