### PR TITLE
Fix event listener warning by not subscriping close for every script

### DIFF
--- a/src/daemon-command/handle-log-socket-close.ts
+++ b/src/daemon-command/handle-log-socket-close.ts
@@ -1,0 +1,12 @@
+import { Socket } from "net";
+
+import { Daemon } from "../commands/start-daemon.command";
+
+export function handleLogSocketClose(daemon: Daemon, socket: Socket): void {
+    for (const script of daemon.scripts) {
+        const index = script.logSockets.findIndex((i) => i == socket);
+        if (index !== -1) {
+            script.logSockets.splice(index, 1);
+        }
+    }
+}

--- a/src/daemon-command/logs.daemon-command.ts
+++ b/src/daemon-command/logs.daemon-command.ts
@@ -1,6 +1,7 @@
 import { Socket } from "net";
 
 import { Daemon } from "../commands/start-daemon.command";
+import { handleLogSocketClose } from "./handle-log-socket-close";
 import { scriptsMatchingPattern } from "./scripts-matching-pattern";
 
 export function logsDaemonCommand(daemon: Daemon, socket: Socket, names: string[]): void {
@@ -15,7 +16,10 @@ export function logsDaemonCommand(daemon: Daemon, socket: Socket, names: string[
         for (const line of script.logBuffer) {
             socket.write(`${script.logPrefix}${line}\n`);
         }
-
         script.addLogSocket(socket);
     }
+
+    socket.on("close", () => {
+        handleLogSocketClose(daemon, socket);
+    });
 }

--- a/src/daemon-command/restart.daemon-command.ts
+++ b/src/daemon-command/restart.daemon-command.ts
@@ -1,6 +1,7 @@
 import { Socket } from "net";
 
 import { Daemon } from "../commands/start-daemon.command";
+import { handleLogSocketClose } from "./handle-log-socket-close";
 import { scriptsMatchingPattern } from "./scripts-matching-pattern";
 
 export interface RestartCommandOptions {
@@ -29,5 +30,9 @@ export async function restartDaemonCommand(daemon: Daemon, socket: Socket, optio
 
     if (!options.follow) {
         socket.end();
+    } else {
+        socket.on("close", () => {
+            handleLogSocketClose(daemon, socket);
+        });
     }
 }

--- a/src/daemon-command/script.ts
+++ b/src/daemon-command/script.ts
@@ -69,12 +69,6 @@ export class Script {
 
     addLogSocket(socket: Socket): void {
         this.logSockets.push(socket);
-        socket.on("close", () => {
-            const index = this.logSockets.findIndex((i) => i == socket);
-            if (index !== -1) {
-                this.logSockets.splice(index, 1);
-            }
-        });
     }
 
     handleLogs(data: Buffer | string): void {

--- a/src/daemon-command/start.daemon-command.ts
+++ b/src/daemon-command/start.daemon-command.ts
@@ -1,6 +1,7 @@
 import { Socket } from "net";
 
 import { Daemon } from "../commands/start-daemon.command";
+import { handleLogSocketClose } from "./handle-log-socket-close";
 import { scriptsMatchingPattern } from "./scripts-matching-pattern";
 
 export interface StartCommandOptions {
@@ -31,5 +32,9 @@ export async function startDaemonCommand(daemon: Daemon, socket: Socket, options
 
     if (!options.follow) {
         socket.end();
+    } else {
+        socket.on("close", () => {
+            handleLogSocketClose(daemon, socket);
+        });
     }
 }


### PR DESCRIPTION
fixes warning 'MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 close listeners added to [Socket]. Use emitter.setMaxListeners() to increase limit' when more than 10 scripts exist