### PR TITLE
partially revert #36, it did have it's use to kill child processes when daemon process exits

### DIFF
--- a/src/commands/start-daemon.command.ts
+++ b/src/commands/start-daemon.command.ts
@@ -1,3 +1,4 @@
+import colors from "colors";
 import { existsSync } from "fs";
 import { createServer, Server } from "net";
 
@@ -71,5 +72,13 @@ export const startDaemon = async (): Promise<void> => {
 
     process.on("SIGTERM", function () {
         shutdown(daemon);
+    });
+
+    const events = ["rejectionHandled", "uncaughtException", "SIGABRT", "SIGHUP", "SIGPWR", "SIGQUIT"];
+    events.forEach((eventName) => {
+        process.on(eventName, (...args) => {
+            console.log(`${colors.bgRed.bold.black(" dev-pm ")} unhandled error event "${eventName}" was called with args: ${args.join(",")}`);
+            shutdown(daemon);
+        });
     });
 };


### PR DESCRIPTION
Leaving child processes running will result in blocked ports and other issues, so if the daemon crashes it should try to kill them too.