### PR TITLE
Add support for .env files using dotenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next
+
+### Changes
+
+-   add support for .env files using dotenv and dotenv-expand to allow usage of .env vars in waitOn
+
 ## 2.1.0
 
 _Jan 11, 2023_

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
         "cli-table3": "^0.6.1",
         "colors": "^1.4.0",
         "commander": "^9.0.0",
+        "dotenv": "^16.0.3",
+        "dotenv-expand": "^10.0.0",
         "log-update": "^4.0.0",
         "pidusage": "^3.0.2",
         "pretty-bytes": "^5.6.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,15 @@
 #!/usr/bin/env node
 
 import { Command, Option } from "commander";
+import * as dotenv from "dotenv";
+import * as dotenvExpand from "dotenv-expand";
 
 import { logs, restart, shutdown, start, status } from "./commands";
 import { startDaemon } from "./commands/start-daemon.command";
 import { stop } from "./commands/stop.command";
+
+const env = dotenv.config();
+dotenvExpand.expand(env);
 
 const program = new Command();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,6 +87,8 @@ __metadata:
     cli-table3: ^0.6.1
     colors: ^1.4.0
     commander: ^9.0.0
+    dotenv: ^16.0.3
+    dotenv-expand: ^10.0.0
     eslint: ^8.20.0
     husky: ^8.0.0
     lint-staged: ^12.0.0
@@ -1389,6 +1391,20 @@ __metadata:
   dependencies:
     esutils: ^2.0.2
   checksum: fd7673ca77fe26cd5cba38d816bc72d641f500f1f9b25b83e8ce28827fe2da7ad583a8da26ab6af85f834138cf8dae9f69b0cd6ab925f52ddab1754db44d99ce
+  languageName: node
+  linkType: hard
+
+"dotenv-expand@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "dotenv-expand@npm:10.0.0"
+  checksum: 2a38b470efe0abcb1ac8490421a55e1d764dc9440fd220942bce40965074f3fb00b585f4346020cb0f0f219966ee6b4ee5023458b3e2953fe5b3214de1b314ee
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^16.0.3":
+  version: 16.0.3
+  resolution: "dotenv@npm:16.0.3"
+  checksum: afcf03f373d7a6d62c7e9afea6328e62851d627a4e73f2e12d0a8deae1cd375892004f3021883f8aec85932cd2834b091f568ced92b4774625b321db83b827f8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Currently `waitOn: ["tcp:$POSTGRESQL_PORT"]` only works when POSTGRESQL_PORT is in the env, but not if only in .env.

As a workaround you an use `dotenv -- dev-pm start` which is fine as script in package.json but very inconvenient when using dev-pm directly. (the first call that stats the daemon needs the env!)

With this change we remove the need for dotenv usage outside completely.