### PR TITLE
Add aliases for status and shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next
+
+### Changes
+
+- add shortcuts `list` and `ls` for `status` and `kill` for `shutdown`
+
 ## 2.2.0
 
 _Feb 2, 2023_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-- add shortcuts `list` and `ls` for `status` and `kill` for `shutdown`
+-   add shortcuts `list` and `ls` for `status`, `log` for `logs` and `halt` for `shutdown`
 
 ## 2.2.0
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,9 +20,12 @@ program
         start({ names, follow: !!options.follow });
     });
 
-program.command("logs [name...]").action((names) => {
-    logs(names);
-});
+program
+    .command("logs [name...]")
+    .aliases(["log"])
+    .action((names) => {
+        logs(names);
+    });
 
 program
     .command("status [name...]")
@@ -45,7 +48,7 @@ program.command("stop [name...]").action((names) => {
 
 program
     .command("shutdown")
-    .alias("kill")
+    .alias("halt")
     .action(() => {
         shutdown();
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ program.command("stop [name...]").action((names) => {
 
 program
     .command("shutdown")
-    .alias("del")
+    .alias("kill")
     .action(() => {
         shutdown();
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ program.command("logs [name...]").action((names) => {
 
 program
     .command("status [name...]")
+    .aliases(["list", "ls"])
     .addOption(new Option("-i, --interval [seconds]", "Keep status open and refresh periodically at given interval").preset("1"))
     .action((names, options) => {
         status({ names, interval: options.interval ? parseInt(options.interval) : undefined });
@@ -42,9 +43,12 @@ program.command("stop [name...]").action((names) => {
     stop(names);
 });
 
-program.command("shutdown").action(() => {
-    shutdown();
-});
+program
+    .command("shutdown")
+    .alias("del")
+    .action(() => {
+        shutdown();
+    });
 
 program.command("start-daemon").action(() => {
     startDaemon();


### PR DESCRIPTION
status and shutdown are such long words. Therefore, I suggest adding the shortcuts `list` and `ls` (for `status`) and `kill` (for `shutdown`). 