### PR TITLE
Make engine configuration less strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   add support for .env files using dotenv and dotenv-expand to allow usage of .env vars in waitOn
 -   change stop signal from SIGKILL to SIGINT (to fix issues with stopping docker)
 -   change maximum backoff time from 120s to 30s
+-   less strict engine specification (only require node >= 14)
 
 ## 2.1.0
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
         "yarn-run-all": "^3.0.0"
     },
     "engines": {
-        "node": "14",
-        "yarn": "3"
+        "node": ">=14"
     }
 }


### PR DESCRIPTION
Currently this package produces warnings when e.g. used with node18 or npm

---------

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@comet/dev-process-manager@2.1.0',
npm WARN EBADENGINE   required: { node: '14', yarn: '3' },
npm WARN EBADENGINE   current: { node: 'v18.13.0', npm: '7.19.1' }
npm WARN EBADENGINE }
````