### PR TITLE
Make compatible with NPM 9

### DIFF
--- a/src/daemon-command/script.ts
+++ b/src/daemon-command/script.ts
@@ -118,7 +118,7 @@ export class Script {
         }
 
         this.handleLogs("[dev-pm] starting process...");
-        const NPM_PATH = execSync("npm bin").toString().trim();
+        const NPM_PATH = `${execSync("npm root").toString().trim()}/.bin`;
         this.status = "started";
         const p = spawn("bash", ["-c", this.scriptDefinition.script], {
             detached: true,


### PR DESCRIPTION
`npm bin` was used to generate the path to the local .bin directory. NPM v9 removed the bin command (https://github.blog/changelog/2022-10-24-npm-v9-0-0-released/). Now use `npm root` to generate the path.