### PR TITLE
Use NODE_AUTH_TOKEN env as it was before to fix canary release

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -32,4 +32,4 @@ jobs:
           yarn build
           yarn changeset publish
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,4 +32,4 @@ jobs:
           publish: yarn build && yarn changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
also mentioned here: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages changesets/action docs use NPM_TOKEN tough

I don't know the difference.