### PR TITLE
Report memory/cpu usage recursively for child processes

### DIFF
--- a/.changeset/ten-bikes-bake.md
+++ b/.changeset/ten-bikes-bake.md
@@ -1,0 +1,5 @@
+---
+"@comet/dev-process-manager": minor
+---
+
+Report memory/cpu usage recursively for child processes

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "dotenv": "^16.0.3",
         "dotenv-expand": "^10.0.0",
         "log-update": "^4.0.0",
+        "pidtree": "^0.6.0",
         "pidusage": "^3.0.2",
         "pretty-bytes": "^5.6.0",
         "wait-on": "^6.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -339,6 +339,7 @@ __metadata:
     husky: ^8.0.0
     lint-staged: ^12.0.0
     log-update: ^4.0.0
+    pidtree: ^0.6.0
     pidusage: ^3.0.2
     prettier: ^2.0.0
     pretty-bytes: ^5.6.0
@@ -4340,6 +4341,15 @@ __metadata:
   bin:
     pidtree: bin/pidtree.js
   checksum: 371cd14bbc9bdee2a6a44596dd521dd3565e223481e0b1afffdca3f1c29831850bfa7784114dc30d245d37e7d186cec035e036256b39f75d878d19498fe0df6a
+  languageName: node
+  linkType: hard
+
+"pidtree@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "pidtree@npm:0.6.0"
+  bin:
+    pidtree: bin/pidtree.js
+  checksum: 8fbc073ede9209dd15e80d616e65eb674986c93be49f42d9ddde8dbbd141bb53d628a7ca4e58ab5c370bb00383f67d75df59a9a226dede8fa801267a7030c27a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
When running package.json scripts this always reported the npm usage, not the runned script itself. Cpu can now be above 100%, but I guess that is ok for multiple processes across multiple cpus