### PR TITLE
Change backoff-time to 10s

### DIFF
--- a/.changeset/grumpy-peaches-hang.md
+++ b/.changeset/grumpy-peaches-hang.md
@@ -1,0 +1,5 @@
+---
+"@comet/dev-process-manager": minor
+---
+
+Change maximum backoff time from 30s to 10s

--- a/src/daemon-command/script.ts
+++ b/src/daemon-command/script.ts
@@ -141,7 +141,7 @@ export class Script {
                 this.handleLogs(`[dev-pm] process crashed, restarting...`);
                 this.restartCount++;
                 this.status = "backoff";
-                const waitTime = Math.min(Math.pow(1.3, this.restartCount), 30);
+                const waitTime = Math.min(Math.pow(1.3, this.restartCount), 10);
                 this.handleLogs(`[dev-pm] waiting ${Math.round(waitTime)}s between restarts`);
                 await new Promise((r) => setTimeout(r, waitTime * 1000));
                 if (this.status == "backoff") {


### PR DESCRIPTION
It's annoying restarting crashed services in development manually because waiting 30s is just too long.