### PR TITLE
Fix script matching via groups

### DIFF
--- a/.changeset/rude-kiwis-flash.md
+++ b/.changeset/rude-kiwis-flash.md
@@ -1,0 +1,5 @@
+---
+"@comet/dev-process-manager": patch
+---
+
+Fix script matching via groups, for example, `npx dev-pm logs @api`

--- a/src/daemon-command/scripts-matching-pattern.ts
+++ b/src/daemon-command/scripts-matching-pattern.ts
@@ -16,7 +16,7 @@ export function scriptsMatchingPattern(daemon: Daemon, { patterns }: ScriptsMatc
         const idExists = ids.some((id) => script.id === id);
         const nameExists = names.some((name) => {
             if (name === "all") return true;
-            if (name[0] === "@" && script.groups.includes(name[0])) return true;
+            if (name[0] === "@" && script.groups.includes(name.substring(1))) return true;
             return script.name === name;
         });
 


### PR DESCRIPTION
The change in #79 introduced a bug where matching via groups wouldn't work anymore. The group name was incorrectly checked for the first character of the name, which is always "@". To fix this, we correctly extract the group name from the pattern.