### PR TITLE
Fix canary release

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -34,6 +34,7 @@ jobs:
           echo >> .changeset/canary.md
           echo fake change to always get a canary release >> .changeset/canary.md
           yarn changeset version --snapshot canary
-          yarn run publish --tag canary
+          yarn build
+          yarn changeset publish --tag canary
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: yarn publish
+          publish: yarn build && yarn changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
         "lint:eslint": "eslint src/",
         "lint:tsc": "tsc",
         "build": "tsc",
-        "start": "tsc --watch",
-        "publish": "yarn build && yarn changeset publish"
+        "start": "tsc --watch"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Apparently, NPM calls the publish script when running `npm publish`, resulting in trying to publish the same package twice. We remove the publish script in an attempt to fix it.

See https://stackoverflow.com/questions/71730319/npm-attempts-to-publish-twice for more information.