### PR TITLE
Chore: Downgrade pretty-bytes

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "log-update": "^4.0.0",
         "pidtree": "^0.6.0",
         "pidusage": "^3.0.2",
-        "pretty-bytes": "^6.1.1",
+        "pretty-bytes": "^5.6.0",
         "wait-on": "^7.2.0"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -328,7 +328,7 @@ __metadata:
     pidtree: ^0.6.0
     pidusage: ^3.0.2
     prettier: ^2.0.0
-    pretty-bytes: ^6.1.1
+    pretty-bytes: ^5.6.0
     typescript: ^5.5.3
     wait-on: ^7.2.0
     yarn-run-all: ^3.1.1
@@ -4166,10 +4166,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-bytes@npm:^6.1.1":
-  version: 6.1.1
-  resolution: "pretty-bytes@npm:6.1.1"
-  checksum: 43d29d909d2d88072da2c3d72f8fd0f2d2523c516bfa640aff6e31f596ea1004b6601f4cabc50d14b2cf10e82635ebe5b7d9378f3d5bae1c0067131829421b8a
+"pretty-bytes@npm:^5.6.0":
+  version: 5.6.0
+  resolution: "pretty-bytes@npm:5.6.0"
+  checksum: 9c082500d1e93434b5b291bd651662936b8bd6204ec9fa17d563116a192d6d86b98f6d328526b4e8d783c07d5499e2614a807520249692da9ec81564b2f439cd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
From version 6 pretty-bytes is ESM only. This did not work.