### PR TITLE
Don't inject .env file as real env variables for child processes

### DIFF
--- a/.changeset/chilled-wombats-count.md
+++ b/.changeset/chilled-wombats-count.md
@@ -1,0 +1,7 @@
+---
+"@comet/dev-process-manager": minor
+---
+
+Don't inject .env file as real env variables for child processes
+
+This can cause problems when the child process has a custom .env loading mechanism (eg. additional files such as .env.secrets) but dev-pm sets env vars which overrule the values loaded from .env by child child process

--- a/.changeset/chilled-wombats-count.md
+++ b/.changeset/chilled-wombats-count.md
@@ -2,6 +2,6 @@
 "@comet/dev-process-manager": minor
 ---
 
-Don't inject .env file as real env variables for child processes
+Don't inject .env file as real environment variables for child processes
 
-This can cause problems when the child process has a custom .env loading mechanism (eg. additional files such as .env.secrets) but dev-pm sets env vars which overrule the values loaded from .env by child child process
+This can cause problems when the child process has a custom .env loading mechanism (e.g., additional files such as .env.secrets), but dev-pm sets environment variables which overrule the values loaded by the child process.

--- a/src/daemon-command/script.ts
+++ b/src/daemon-command/script.ts
@@ -1,5 +1,7 @@
 import { ChildProcess, execSync, spawn } from "child_process";
 import colors from "colors";
+import * as dotenv from "dotenv";
+import * as dotenvExpand from "dotenv-expand";
 import { Socket } from "net";
 import waitOn from "wait-on";
 
@@ -7,6 +9,10 @@ import { ScriptDefinition } from "../script-definition.type";
 
 const KEEP_LOG_LINES = 100;
 export type ScriptStatus = "started" | "stopping" | "stopped" | "waiting" | "backoff";
+
+const expandedEnv = { ...(process.env as Record<string, string>) };
+dotenv.config({ processEnv: expandedEnv });
+dotenvExpand.expand({ processEnv: expandedEnv });
 
 export class Script {
     scriptDefinition: ScriptDefinition;
@@ -40,7 +46,7 @@ export class Script {
         const waitOn = Array.isArray(this.scriptDefinition.waitOn) ? this.scriptDefinition.waitOn : [this.scriptDefinition.waitOn];
         return waitOn.map((str) =>
             str.replace(/\$[a-z\d_]+/gi, function (match) {
-                const sub = process.env[match.substring(1)];
+                const sub = expandedEnv[match.substring(1)];
                 return sub || match;
             }),
         );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,12 @@
 #!/usr/bin/env node
 
 import { Command, Option } from "commander";
-import * as dotenv from "dotenv";
-import * as dotenvExpand from "dotenv-expand";
 
 import { logs, restart, shutdown, start, status } from "./commands";
 import { startDaemon } from "./commands/start-daemon.command";
 import { stop } from "./commands/stop.command";
 
 export { Config } from "./config.type";
-
-const env = dotenv.config();
-dotenvExpand.expand(env);
 
 const program = new Command();
 // eslint-disable-next-line @typescript-eslint/no-var-requires


### PR DESCRIPTION
This can cause problems when the child process has a custom .env loading mechanism (eg. additional files such as .env.secrets) but dev-pm sets env vars which overrule the values loaded from .env by child child process

