### PR TITLE
Convert to ESM

### DIFF
--- a/.changeset/giant-boats-suffer.md
+++ b/.changeset/giant-boats-suffer.md
@@ -1,5 +1,5 @@
 ---
-"@comet/dev-process-manager": minor
+"@comet/dev-process-manager": major
 ---
 
-Convert to ESM
+Require Node v18 or later

--- a/.changeset/giant-boats-suffer.md
+++ b/.changeset/giant-boats-suffer.md
@@ -1,0 +1,5 @@
+---
+"@comet/dev-process-manager": minor
+---
+
+Convert to ESM

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "packageManager": "yarn@3.2.0",
     "license": "BSD-2-Clause",
     "version": "2.7.1",
-    "main": "lib/index.js",
+    "exports": "lib/index.js",
     "types": "lib/index.d.ts",
     "bin": {
         "dev-pm": "lib/dev-pm.js"

--- a/package.json
+++ b/package.json
@@ -60,5 +60,6 @@
     },
     "engines": {
         "node": ">=14"
-    }
+    },
+    "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "yarn-run-all": "^3.1.1"
     },
     "engines": {
-        "node": ">=14"
+        "node": ">=18"
     },
     "type": "module"
 }

--- a/src/commands/auto-start-daemon.ts
+++ b/src/commands/auto-start-daemon.ts
@@ -1,7 +1,7 @@
 import { spawn } from "child_process";
 import { existsSync } from "fs";
 
-import { findConfigDir } from "../utils/find-config-dir";
+import { findConfigDir } from "../utils/find-config-dir.js";
 
 export async function autoStartDaemon(): Promise<void> {
     if (existsSync(`${findConfigDir()}/.pm.sock`)) {

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -1,7 +1,7 @@
 import { createConnection, Socket } from "net";
 
-import { findConfigDir } from "../utils/find-config-dir";
-import { autoStartDaemon } from "./auto-start-daemon";
+import { findConfigDir } from "../utils/find-config-dir.js";
+import { autoStartDaemon } from "./auto-start-daemon.js";
 
 export async function connect(): Promise<Socket> {
     await autoStartDaemon();

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,5 +1,5 @@
-export { logs } from "./logs.command";
-export { restart } from "./restart.command";
-export { shutdown } from "./shutdown.command";
-export { start } from "./start.command";
-export { status } from "./status.command";
+export { logs } from "./logs.command.js";
+export { restart } from "./restart.command.js";
+export { shutdown } from "./shutdown.command.js";
+export { start } from "./start.command.js";
+export { status } from "./status.command.js";

--- a/src/commands/logs.command.ts
+++ b/src/commands/logs.command.ts
@@ -1,5 +1,5 @@
-import { LogsCommandOptions } from "../daemon-command/logs.daemon-command";
-import { connect } from "./connect";
+import { LogsCommandOptions } from "../daemon-command/logs.daemon-command.js";
+import { connect } from "./connect.js";
 
 export const logs = async (options: LogsCommandOptions): Promise<void> => {
     const client = await connect();

--- a/src/commands/restart.command.ts
+++ b/src/commands/restart.command.ts
@@ -1,5 +1,5 @@
-import { RestartCommandOptions } from "../daemon-command/restart.daemon-command";
-import { connect } from "./connect";
+import { RestartCommandOptions } from "../daemon-command/restart.daemon-command.js";
+import { connect } from "./connect.js";
 
 export const restart = async (options: RestartCommandOptions): Promise<void> => {
     const client = await connect();

--- a/src/commands/shutdown.command.ts
+++ b/src/commands/shutdown.command.ts
@@ -1,4 +1,4 @@
-import { connect } from "./connect";
+import { connect } from "./connect.js";
 
 export const shutdown = async (): Promise<void> => {
     const client = await connect();

--- a/src/commands/start-daemon.command.ts
+++ b/src/commands/start-daemon.command.ts
@@ -2,16 +2,16 @@ import colors from "colors";
 import { existsSync, watchFile } from "fs";
 import { createServer, Server } from "net";
 
-import { Config } from "../config.type";
-import { logsDaemonCommand } from "../daemon-command/logs.daemon-command";
-import { restartDaemonCommand } from "../daemon-command/restart.daemon-command";
-import { Script } from "../daemon-command/script";
-import { shutdown } from "../daemon-command/shutdown";
-import { shutdownDaemonCommand } from "../daemon-command/shutdown.daemon-command";
-import { startDaemonCommand } from "../daemon-command/start.daemon-command";
-import { statusDaemonCommand } from "../daemon-command/status.daemon-command";
-import { stopDaemonCommand } from "../daemon-command/stop.daemon-command";
-import { findConfigDir } from "../utils/find-config-dir";
+import { Config } from "../config.type.js";
+import { logsDaemonCommand } from "../daemon-command/logs.daemon-command.js";
+import { restartDaemonCommand } from "../daemon-command/restart.daemon-command.js";
+import { Script } from "../daemon-command/script.js";
+import { shutdownDaemonCommand } from "../daemon-command/shutdown.daemon-command.js";
+import { shutdown } from "../daemon-command/shutdown.js";
+import { startDaemonCommand } from "../daemon-command/start.daemon-command.js";
+import { statusDaemonCommand } from "../daemon-command/status.daemon-command.js";
+import { stopDaemonCommand } from "../daemon-command/stop.daemon-command.js";
+import { findConfigDir } from "../utils/find-config-dir.js";
 
 export interface Daemon {
     scripts: Script[];

--- a/src/commands/start.command.ts
+++ b/src/commands/start.command.ts
@@ -1,5 +1,5 @@
-import { StartCommandOptions } from "../daemon-command/start.daemon-command";
-import { connect } from "./connect";
+import { StartCommandOptions } from "../daemon-command/start.daemon-command.js";
+import { connect } from "./connect.js";
 
 export const start = async (options: StartCommandOptions): Promise<void> => {
     const client = await connect();

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -1,5 +1,5 @@
-import { StatusCommandOptions } from "../daemon-command/status.daemon-command";
-import { connect } from "./connect";
+import { StatusCommandOptions } from "../daemon-command/status.daemon-command.js";
+import { connect } from "./connect.js";
 
 export const status = async (options: StatusCommandOptions): Promise<void> => {
     const client = await connect();

--- a/src/commands/stop.command.ts
+++ b/src/commands/stop.command.ts
@@ -1,5 +1,5 @@
-import { StopCommandOptions } from "../daemon-command/stop.daemon-command";
-import { connect } from "./connect";
+import { StopCommandOptions } from "../daemon-command/stop.daemon-command.js";
+import { connect } from "./connect.js";
 
 export const stop = async (options: StopCommandOptions): Promise<void> => {
     const client = await connect();

--- a/src/config.type.ts
+++ b/src/config.type.ts
@@ -1,4 +1,4 @@
-import { ScriptDefinition } from "./script-definition.type";
+import { ScriptDefinition } from "./script-definition.type.js";
 
 export interface Config {
     // ID is set by the daemon

--- a/src/daemon-command/handle-log-socket-close.ts
+++ b/src/daemon-command/handle-log-socket-close.ts
@@ -1,6 +1,6 @@
 import { Socket } from "net";
 
-import { Daemon } from "../commands/start-daemon.command";
+import { Daemon } from "../commands/start-daemon.command.js";
 
 export function handleLogSocketClose(daemon: Daemon, socket: Socket): void {
     for (const script of daemon.scripts) {

--- a/src/daemon-command/logs.daemon-command.ts
+++ b/src/daemon-command/logs.daemon-command.ts
@@ -1,8 +1,8 @@
 import { Socket } from "net";
 
-import { Daemon } from "../commands/start-daemon.command";
-import { handleLogSocketClose } from "./handle-log-socket-close";
-import { scriptsMatchingPattern, ScriptsMatchingPatternOptions } from "./scripts-matching-pattern";
+import { Daemon } from "../commands/start-daemon.command.js";
+import { handleLogSocketClose } from "./handle-log-socket-close.js";
+import { scriptsMatchingPattern, ScriptsMatchingPatternOptions } from "./scripts-matching-pattern.js";
 
 export type LogsCommandOptions = ScriptsMatchingPatternOptions;
 

--- a/src/daemon-command/restart.daemon-command.ts
+++ b/src/daemon-command/restart.daemon-command.ts
@@ -1,8 +1,8 @@
 import { Socket } from "net";
 
-import { Daemon } from "../commands/start-daemon.command";
-import { handleLogSocketClose } from "./handle-log-socket-close";
-import { scriptsMatchingPattern, ScriptsMatchingPatternOptions } from "./scripts-matching-pattern";
+import { Daemon } from "../commands/start-daemon.command.js";
+import { handleLogSocketClose } from "./handle-log-socket-close.js";
+import { scriptsMatchingPattern, ScriptsMatchingPatternOptions } from "./scripts-matching-pattern.js";
 
 export interface RestartCommandOptions extends ScriptsMatchingPatternOptions {
     follow: boolean;

--- a/src/daemon-command/script.ts
+++ b/src/daemon-command/script.ts
@@ -5,7 +5,7 @@ import * as dotenvExpand from "dotenv-expand";
 import { Socket } from "net";
 import waitOn from "wait-on";
 
-import { ScriptDefinition } from "../script-definition.type";
+import { ScriptDefinition } from "../script-definition.type.js";
 
 const KEEP_LOG_LINES = 100;
 export type ScriptStatus = "started" | "stopping" | "stopped" | "waiting" | "backoff";

--- a/src/daemon-command/scripts-matching-pattern.ts
+++ b/src/daemon-command/scripts-matching-pattern.ts
@@ -1,5 +1,5 @@
-import { Daemon } from "../commands/start-daemon.command";
-import { Script } from "./script";
+import { Daemon } from "../commands/start-daemon.command.js";
+import { Script } from "./script.js";
 
 export interface ScriptsMatchingPatternOptions {
     patterns: string[];

--- a/src/daemon-command/shutdown.daemon-command.ts
+++ b/src/daemon-command/shutdown.daemon-command.ts
@@ -1,7 +1,7 @@
 import { Socket } from "net";
 
-import { Daemon } from "../commands/start-daemon.command";
-import { shutdown } from "./shutdown";
+import { Daemon } from "../commands/start-daemon.command.js";
+import { shutdown } from "./shutdown.js";
 
 export function shutdownDaemonCommand(daemon: Daemon, socket: Socket): void {
     //    socket.destroy(); //probably too early, doesn't allow us to send output

--- a/src/daemon-command/shutdown.ts
+++ b/src/daemon-command/shutdown.ts
@@ -1,7 +1,7 @@
 import colors from "colors";
 import { Socket } from "net";
 
-import { Daemon } from "../commands/start-daemon.command";
+import { Daemon } from "../commands/start-daemon.command.js";
 
 export const shutdown = async (daemon: Daemon, socket?: Socket): Promise<void> => {
     console.log(`${colors.bgGreen.bold.black(" dev-pm ")} shutting down`);

--- a/src/daemon-command/start.daemon-command.ts
+++ b/src/daemon-command/start.daemon-command.ts
@@ -1,8 +1,8 @@
 import { Socket } from "net";
 
-import { Daemon } from "../commands/start-daemon.command";
-import { handleLogSocketClose } from "./handle-log-socket-close";
-import { scriptsMatchingPattern, ScriptsMatchingPatternOptions } from "./scripts-matching-pattern";
+import { Daemon } from "../commands/start-daemon.command.js";
+import { handleLogSocketClose } from "./handle-log-socket-close.js";
+import { scriptsMatchingPattern, ScriptsMatchingPatternOptions } from "./scripts-matching-pattern.js";
 
 export interface StartCommandOptions extends ScriptsMatchingPatternOptions {
     follow: boolean;

--- a/src/daemon-command/status.daemon-command.ts
+++ b/src/daemon-command/status.daemon-command.ts
@@ -6,9 +6,9 @@ import pidtree from "pidtree";
 import pidusage from "pidusage";
 import prettyBytes from "pretty-bytes";
 
-import { Daemon } from "../commands/start-daemon.command";
-import { ScriptStatus } from "./script";
-import { scriptsMatchingPattern, ScriptsMatchingPatternOptions } from "./scripts-matching-pattern";
+import { Daemon } from "../commands/start-daemon.command.js";
+import { ScriptStatus } from "./script.js";
+import { scriptsMatchingPattern, ScriptsMatchingPatternOptions } from "./scripts-matching-pattern.js";
 
 export interface StatusCommandOptions extends ScriptsMatchingPatternOptions {
     interval: number | undefined;

--- a/src/daemon-command/stop.daemon-command.ts
+++ b/src/daemon-command/stop.daemon-command.ts
@@ -1,7 +1,7 @@
 import { Socket } from "net";
 
-import { Daemon } from "../commands/start-daemon.command";
-import { scriptsMatchingPattern, ScriptsMatchingPatternOptions } from "./scripts-matching-pattern";
+import { Daemon } from "../commands/start-daemon.command.js";
+import { scriptsMatchingPattern, ScriptsMatchingPatternOptions } from "./scripts-matching-pattern.js";
 
 export type StopCommandOptions = ScriptsMatchingPatternOptions;
 

--- a/src/dev-pm.ts
+++ b/src/dev-pm.ts
@@ -1,14 +1,21 @@
 #!/usr/bin/env node
 
 import { Command, Option } from "commander";
+import { readFileSync } from "fs";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
 
-import { logs, restart, shutdown, start, status } from "./commands";
-import { startDaemon } from "./commands/start-daemon.command";
-import { stop } from "./commands/stop.command";
+import { logs, restart, shutdown, start, status } from "./commands/index.js";
+import { startDaemon } from "./commands/start-daemon.command.js";
+import { stop } from "./commands/stop.command.js";
 
 const program = new Command();
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-program.version(require("../package.json").version);
+
+{
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const { version } = JSON.parse(readFileSync(resolve(__dirname, "../package.json"), "utf-8"));
+    program.version(version);
+}
 
 program
     .command("start [patterns...]")

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { Config } from "./config.type";
+export { Config } from "./config.type.js";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "compilerOptions": {
-        "module": "CommonJS",
-        "target": "ES2015",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "target": "ES2020",
         "lib": ["ES2020"],
         "outDir": "./lib",
         "baseUrl": "./",


### PR DESCRIPTION
Convert this package to ESM

- the bin script dev-pm is not affected by this internal change
- the only public api is the exported Config type: I did a quick test by copying the package into comet, types where resolved correctly

This is done in preparation for https://github.com/vivid-planet/dev-process-manager/pull/106, so we can use unconfig, which is ESM-only.