### PR TITLE
Fix package.json fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
     "packageManager": "yarn@3.2.0",
     "license": "BSD-2-Clause",
     "version": "2.7.1",
-    "exports": "lib/index.js",
-    "types": "lib/index.d.ts",
+    "exports": "./lib/index.js",
+    "types": "./lib/index.d.ts",
     "bin": {
         "dev-pm": "lib/dev-pm.js"
     },


### PR DESCRIPTION
## Description

Fix `exports` and `types` fields after switching to ESM. I noticed that the config type wasn't resolved while testing the canary release in the Comet repository.