### PR TITLE
Show a nice console error when config is invalid

### DIFF
--- a/.changeset/light-lions-destroy.md
+++ b/.changeset/light-lions-destroy.md
@@ -1,0 +1,5 @@
+---
+"@comet/dev-process-manager": minor
+---
+
+Show a nice console error when config is invalid

--- a/src/commands/logs.command.ts
+++ b/src/commands/logs.command.ts
@@ -1,7 +1,9 @@
 import { LogsCommandOptions } from "../daemon-command/logs.daemon-command.js";
 import { connect } from "./connect.js";
+import { validConfigOrExit } from "./validate-config.js";
 
 export const logs = async (options: LogsCommandOptions): Promise<void> => {
+    await validConfigOrExit();
     const client = await connect();
     client.write(`logs ${JSON.stringify(options)}`);
 };

--- a/src/commands/restart.command.ts
+++ b/src/commands/restart.command.ts
@@ -1,7 +1,9 @@
 import { RestartCommandOptions } from "../daemon-command/restart.daemon-command.js";
 import { connect } from "./connect.js";
+import { validConfigOrExit } from "./validate-config.js";
 
 export const restart = async (options: RestartCommandOptions): Promise<void> => {
+    await validConfigOrExit();
     const client = await connect();
     client.write(`restart ${JSON.stringify(options)}`);
 };

--- a/src/commands/shutdown.command.ts
+++ b/src/commands/shutdown.command.ts
@@ -1,6 +1,8 @@
 import { connect } from "./connect.js";
+import { validConfigOrExit } from "./validate-config.js";
 
 export const shutdown = async (): Promise<void> => {
+    await validConfigOrExit();
     const client = await connect();
     client.write("shutdown");
 };

--- a/src/commands/start.command.ts
+++ b/src/commands/start.command.ts
@@ -1,7 +1,9 @@
 import { StartCommandOptions } from "../daemon-command/start.daemon-command.js";
 import { connect } from "./connect.js";
+import { validConfigOrExit } from "./validate-config.js";
 
 export const start = async (options: StartCommandOptions): Promise<void> => {
+    await validConfigOrExit();
     const client = await connect();
     client.write(`start ${JSON.stringify(options)}`);
 };

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -1,7 +1,9 @@
 import { StatusCommandOptions } from "../daemon-command/status.daemon-command.js";
 import { connect } from "./connect.js";
+import { validConfigOrExit } from "./validate-config.js";
 
 export const status = async (options: StatusCommandOptions): Promise<void> => {
+    await validConfigOrExit();
     const client = await connect();
     client.write(`status ${JSON.stringify(options)}`);
 };

--- a/src/commands/stop.command.ts
+++ b/src/commands/stop.command.ts
@@ -1,7 +1,9 @@
 import { StopCommandOptions } from "../daemon-command/stop.daemon-command.js";
 import { connect } from "./connect.js";
+import { validConfigOrExit } from "./validate-config.js";
 
 export const stop = async (options: StopCommandOptions): Promise<void> => {
+    await validConfigOrExit();
     const client = await connect();
     client.write(`stop ${JSON.stringify(options)}`);
 };

--- a/src/commands/validate-config.ts
+++ b/src/commands/validate-config.ts
@@ -1,0 +1,17 @@
+import { loadConfig } from "../utils/load-config.js";
+
+/**
+ * Load config and output errors if any on console and exit process
+ */
+export async function validConfigOrExit() {
+    try {
+        await loadConfig();
+    } catch (error) {
+        if (error instanceof Error) {
+            console.error(error.message);
+        } else {
+            console.error(error);
+        }
+        process.exit(1);
+    }
+}

--- a/src/utils/load-config.ts
+++ b/src/utils/load-config.ts
@@ -3,7 +3,7 @@ import { loadConfig as unconfigLoadConfig } from "unconfig";
 import { Config } from "../config.js";
 
 export async function loadConfig() {
-    return unconfigLoadConfig<Config>({
+    const config = await unconfigLoadConfig<Config>({
         sources: [
             {
                 files: "dev-pm.config",
@@ -12,4 +12,14 @@ export async function loadConfig() {
         ],
         merge: false,
     });
+    if (!config.sources.length) {
+        throw new Error("dev-pm.config file not found");
+    }
+    if (Object.keys(config.config).length === 0) {
+        throw new Error("dev-pm.config doesn't export a config object, make sure to add a default export");
+    }
+    if (!config.config.scripts) {
+        throw new Error("dev-pm.config doesn't include required scripts");
+    }
+    return config;
 }


### PR DESCRIPTION
Before the start-daemon background process crashed on invalid config (eg when `export default` is forgotten) showing no error in eg. `dpm status`. Now the config is validated before trying to start the background process and a nice error is shown.

example output:
```
niko@niko:~/dev/dev-process-manager/example validate-config$ node ../lib/dev-pm.js start
dev-pm.config doesn't export a config object, make sure to add a default export
niko@niko:~/dev/dev-process-manager/example validate-config$ cd ../example2/
niko@niko:~/dev/dev-process-manager/example2 validate-config$ node ../lib/dev-pm.js start
dev-pm.config file not found
```