### PR TITLE
Add missing newline to 'no matching scripts' error

### DIFF
--- a/.changeset/many-masks-flow.md
+++ b/.changeset/many-masks-flow.md
@@ -1,0 +1,5 @@
+---
+"@comet/dev-process-manager": patch
+---
+
+Add missing newline to 'no matching scripts' error

--- a/src/daemon-command/logs.daemon-command.ts
+++ b/src/daemon-command/logs.daemon-command.ts
@@ -9,7 +9,7 @@ export type LogsCommandOptions = ScriptsMatchingPatternOptions;
 export function logsDaemonCommand(daemon: Daemon, socket: Socket, options: LogsCommandOptions): void {
     const scriptsToProcess = scriptsMatchingPattern(daemon, { patterns: options.patterns });
     if (!scriptsToProcess.length) {
-        socket.write("No matching scripts found in dev-pm config");
+        socket.write("No matching scripts found in dev-pm config\n");
         socket.end();
         return;
     }

--- a/src/daemon-command/restart.daemon-command.ts
+++ b/src/daemon-command/restart.daemon-command.ts
@@ -10,7 +10,7 @@ export interface RestartCommandOptions extends ScriptsMatchingPatternOptions {
 export async function restartDaemonCommand(daemon: Daemon, socket: Socket, options: RestartCommandOptions): Promise<void> {
     const scriptsToProcess = scriptsMatchingPattern(daemon, { patterns: options.patterns });
     if (!scriptsToProcess.length) {
-        socket.write("No matching scripts found in dev-pm config");
+        socket.write("No matching scripts found in dev-pm config\n");
         socket.end();
         return;
     }

--- a/src/daemon-command/status.daemon-command.ts
+++ b/src/daemon-command/status.daemon-command.ts
@@ -38,7 +38,7 @@ async function pidusageRecursive(pid: number): Promise<{ cpu: number; memory: nu
 export async function statusDaemonCommand(daemon: Daemon, socket: Socket, options: StatusCommandOptions): Promise<void> {
     const scriptsToProcess = scriptsMatchingPattern(daemon, { patterns: options.patterns });
     if (!scriptsToProcess.length) {
-        socket.write("No matching scripts found in dev-pm config");
+        socket.write("No matching scripts found in dev-pm config\n");
         socket.end();
         return;
     }

--- a/src/daemon-command/stop.daemon-command.ts
+++ b/src/daemon-command/stop.daemon-command.ts
@@ -8,7 +8,7 @@ export type StopCommandOptions = ScriptsMatchingPatternOptions;
 export async function stopDaemonCommand(daemon: Daemon, socket: Socket, options: StopCommandOptions): Promise<void> {
     const scriptsToProcess = scriptsMatchingPattern(daemon, { patterns: options.patterns });
     if (!scriptsToProcess.length) {
-        socket.write("No matching scripts found in dev-pm config");
+        socket.write("No matching scripts found in dev-pm config\n");
         socket.end();
         return;
     }


### PR DESCRIPTION
Maybe this fixes the problem that no error is shown on mac
