### PR TITLE
Add missing newline to 'no matching scripts' error (for real)

### DIFF
--- a/src/daemon-command/start.daemon-command.ts
+++ b/src/daemon-command/start.daemon-command.ts
@@ -10,7 +10,7 @@ export interface StartCommandOptions extends ScriptsMatchingPatternOptions {
 export async function startDaemonCommand(daemon: Daemon, socket: Socket, options: StartCommandOptions): Promise<void> {
     const scriptsToProcess = scriptsMatchingPattern(daemon, { patterns: options.patterns });
     if (!scriptsToProcess.length) {
-        socket.write("No matching scripts found in dev-pm config");
+        socket.write("No matching scripts found in dev-pm config\n");
         socket.end();
         return;
     }


### PR DESCRIPTION
## Description

The fix from https://github.com/vivid-planet/dev-process-manager/pull/115 works on macOS, but was forgotten in one case.