### PR TITLE
Refactor status command to use JSON protocol

### DIFF
--- a/.changeset/status-json-protocol.md
+++ b/.changeset/status-json-protocol.md
@@ -1,0 +1,5 @@
+---
+"@comet/dev-process-manager": minor
+---
+
+Internal: the daemon now sends status as structured JSON and the table rendering is done in the CLI client (no change to the `status` output)

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -20,9 +20,12 @@ export async function connect(): Promise<Socket> {
         client.on("connect", () => {
             resolve(client);
         });
-        client.on("data", (data) => {
-            //TODO handle stderr/stdin and also write on stderr
-            process.stdout.write(data);
-        });
+    });
+}
+
+export function pipeToStdout(client: Socket): void {
+    client.on("data", (data) => {
+        //TODO handle stderr/stdin and also write on stderr
+        process.stdout.write(data);
     });
 }

--- a/src/commands/logs.command.ts
+++ b/src/commands/logs.command.ts
@@ -1,9 +1,10 @@
 import { type LogsCommandOptions } from "../daemon-command/logs.daemon-command.js";
-import { connect } from "./connect.js";
+import { connect, pipeToStdout } from "./connect.js";
 import { validConfigOrExit } from "./validate-config.js";
 
 export const logs = async (options: LogsCommandOptions): Promise<void> => {
     await validConfigOrExit();
     const client = await connect();
+    pipeToStdout(client);
     client.write(`logs ${JSON.stringify(options)}`);
 };

--- a/src/commands/restart.command.ts
+++ b/src/commands/restart.command.ts
@@ -1,9 +1,10 @@
 import { type RestartCommandOptions } from "../daemon-command/restart.daemon-command.js";
-import { connect } from "./connect.js";
+import { connect, pipeToStdout } from "./connect.js";
 import { validConfigOrExit } from "./validate-config.js";
 
 export const restart = async (options: RestartCommandOptions): Promise<void> => {
     await validConfigOrExit();
     const client = await connect();
+    pipeToStdout(client);
     client.write(`restart ${JSON.stringify(options)}`);
 };

--- a/src/commands/shutdown.command.ts
+++ b/src/commands/shutdown.command.ts
@@ -1,8 +1,9 @@
-import { connect } from "./connect.js";
+import { connect, pipeToStdout } from "./connect.js";
 import { validConfigOrExit } from "./validate-config.js";
 
 export const shutdown = async (): Promise<void> => {
     await validConfigOrExit();
     const client = await connect();
+    pipeToStdout(client);
     client.write("shutdown");
 };

--- a/src/commands/start.command.ts
+++ b/src/commands/start.command.ts
@@ -1,9 +1,10 @@
 import { type StartCommandOptions } from "../daemon-command/start.daemon-command.js";
-import { connect } from "./connect.js";
+import { connect, pipeToStdout } from "./connect.js";
 import { validConfigOrExit } from "./validate-config.js";
 
 export const start = async (options: StartCommandOptions): Promise<void> => {
     await validConfigOrExit();
     const client = await connect();
+    pipeToStdout(client);
     client.write(`start ${JSON.stringify(options)}`);
 };

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -1,9 +1,67 @@
-import { type StatusCommandOptions } from "../daemon-command/status.daemon-command.js";
+import CLITable from "cli-table3";
+import colors from "colors";
+import { create as createLogUpdate } from "log-update";
+
+import { type ScriptStatus } from "../daemon-command/script.js";
+import { type ScriptStatusEntry, type StatusCommandOptions } from "../daemon-command/status.daemon-command.js";
 import { connect } from "./connect.js";
 import { validConfigOrExit } from "./validate-config.js";
+
+const statusTexts: { [status in ScriptStatus]: string } = {
+    started: colors.green("Running"),
+    stopping: colors.red("Stopping"),
+    stopped: "Stopped",
+    waiting: colors.yellow("Waiting"),
+    backoff: colors.red("Backoff"),
+};
+
+function renderTable(entries: ScriptStatusEntry[]): string {
+    const table = new CLITable({
+        head: [
+            colors.blue.bold("ID"),
+            colors.blue.bold("Script"),
+            colors.blue.bold("Status"),
+            colors.blue.bold("CPU"),
+            colors.blue.bold("Mem"),
+            colors.bold.blue("PID"),
+            colors.bold.blue("Restarts"),
+        ],
+        style: { compact: true },
+    });
+    for (const entry of entries) {
+        table.push([entry.id, entry.name, statusTexts[entry.status], entry.cpu, entry.memory, entry.pid?.toString(), entry.restarts]);
+    }
+    return table.toString();
+}
 
 export const status = async (options: StatusCommandOptions): Promise<void> => {
     await validConfigOrExit();
     const client = await connect();
+
+    const logUpdate = options.interval ? createLogUpdate(process.stdout) : undefined;
+    let buffer = "";
+
+    client.on("data", (data: Buffer) => {
+        buffer += data.toString();
+        let newlineIndex: number;
+        while ((newlineIndex = buffer.indexOf("\n")) !== -1) {
+            const line = buffer.substring(0, newlineIndex);
+            buffer = buffer.substring(newlineIndex + 1);
+
+            const parsed = JSON.parse(line);
+            if (parsed.error) {
+                console.log(parsed.error);
+                return;
+            }
+
+            const output = renderTable(parsed as ScriptStatusEntry[]);
+            if (logUpdate) {
+                logUpdate(output);
+            } else {
+                console.log(output);
+            }
+        }
+    });
+
     client.write(`status ${JSON.stringify(options)}`);
 };

--- a/src/commands/stop.command.ts
+++ b/src/commands/stop.command.ts
@@ -1,9 +1,10 @@
 import { type StopCommandOptions } from "../daemon-command/stop.daemon-command.js";
-import { connect } from "./connect.js";
+import { connect, pipeToStdout } from "./connect.js";
 import { validConfigOrExit } from "./validate-config.js";
 
 export const stop = async (options: StopCommandOptions): Promise<void> => {
     await validConfigOrExit();
     const client = await connect();
+    pipeToStdout(client);
     client.write(`stop ${JSON.stringify(options)}`);
 };

--- a/src/daemon-command/status.daemon-command.ts
+++ b/src/daemon-command/status.daemon-command.ts
@@ -1,6 +1,3 @@
-import CLITable from "cli-table3";
-import colors from "colors";
-import { create as createLogUpdate } from "log-update";
 import { type Socket } from "net";
 import pidtree from "pidtree";
 import pidusage from "pidusage";
@@ -14,13 +11,15 @@ export interface StatusCommandOptions extends ScriptsMatchingPatternOptions {
     interval: number | undefined;
 }
 
-const statusTexts: { [status in ScriptStatus]: string } = {
-    started: colors.green("Started"),
-    stopping: colors.red("Stopping"),
-    stopped: "Stopped",
-    waiting: colors.yellow("Waiting"),
-    backoff: colors.red("Backoff"),
-};
+export interface ScriptStatusEntry {
+    id: number;
+    name: string;
+    status: ScriptStatus;
+    cpu: string;
+    memory: string;
+    pid: number | undefined;
+    restarts: number;
+}
 
 async function pidusageRecursive(pid: number): Promise<{ cpu: number; memory: number }> {
     const pids = await pidtree(pid, { root: true });
@@ -35,63 +34,47 @@ async function pidusageRecursive(pid: number): Promise<{ cpu: number; memory: nu
     );
 }
 
+async function getScriptEntries(daemon: Daemon, patterns: string[]): Promise<ScriptStatusEntry[]> {
+    const scriptsToProcess = scriptsMatchingPattern(daemon, { patterns });
+    const entries: ScriptStatusEntry[] = [];
+    for (const script of scriptsToProcess) {
+        const pid = script.process?.pid;
+        let cpu = "";
+        let memory = "";
+        if (pid && script.status == "started") {
+            try {
+                const stats = await pidusageRecursive(pid);
+                cpu = `${Math.round(stats.cpu)}%`;
+                memory = prettyBytes(stats.memory);
+            } catch {
+                //
+            }
+        }
+        entries.push({
+            id: script.id,
+            name: script.name,
+            status: script.status,
+            cpu,
+            memory,
+            pid,
+            restarts: script.restartCount,
+        });
+    }
+    return entries;
+}
+
 export async function statusDaemonCommand(daemon: Daemon, socket: Socket, options: StatusCommandOptions): Promise<void> {
     const scriptsToProcess = scriptsMatchingPattern(daemon, { patterns: options.patterns });
     if (!scriptsToProcess.length) {
-        socket.write("No matching scripts found in dev-pm config\n");
+        socket.write(`${JSON.stringify({ error: "No matching scripts found in dev-pm config" })}\n`);
         socket.end();
         return;
     }
 
-    //log-update reads rows/columns from terminal, but in our case it's a socket that doesn't contain those
-    //inject a high enough number so will refresh more rows and don't wrap too early
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    socket.rows = 1000;
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    socket.columns = 200;
-
-    const logUpdate = createLogUpdate(socket);
-
     do {
-        const table = new CLITable({
-            head: [
-                colors.blue.bold("ID"),
-                colors.blue.bold("Script"),
-                colors.blue.bold("Status"),
-                colors.blue.bold("CPU"),
-                colors.blue.bold("Mem"),
-                colors.bold.blue("PID"),
-                colors.bold.blue("Restarts"),
-            ],
-            style: { compact: true },
-        });
-        for (const script of scriptsToProcess) {
-            const pid = script.process?.pid;
-            let status = statusTexts[script.status];
-            if (script.status == "started") {
-                if (pid) {
-                    status = colors.green("Running");
-                }
-            }
-
-            let cpu = "";
-            let memory = "";
-            if (pid && script.status == "started") {
-                try {
-                    const stats = await pidusageRecursive(pid);
-                    cpu = `${Math.round(stats.cpu)}%`;
-                    memory = prettyBytes(stats.memory);
-                } catch {
-                    //
-                }
-            }
-            table.push([script.id, script.name, status, cpu, memory, pid?.toString(), script.restartCount]);
-        }
-
+        const entries = await getScriptEntries(daemon, options.patterns);
         if (!socket.writable) break;
-        logUpdate(table.toString());
+        socket.write(`${JSON.stringify(entries)}\n`);
         if (options.interval) {
             await delay(options.interval * 1000);
         }


### PR DESCRIPTION
mainly in preparation for #177, but imho generally a better idea to use a json protocol and render the table client side.

## Description

The status command previously rendered tables directly in the daemon process and streamed the formatted output to the client. This approach mixed presentation logic with daemon logic and made it difficult to handle the status command differently from other commands.

This change separates concerns by:
1. Moving table rendering logic from the daemon to the client command
2. Having the daemon send structured JSON data instead of formatted text
3. Extracting script status data collection into a reusable `getScriptEntries()` function
4. Exporting a new `ScriptStatusEntry` interface for type safety

Additionally, the `connect()` function's default data handler is extracted into a new `pipeToStdout()` function, which is now explicitly called by commands that need it (logs, restart, shutdown, start, stop). This allows the status command to handle data differently without affecting other commands.

**Benefits:**
- Cleaner separation between daemon and client concerns
- Status command can now parse and render data on the client side
- Easier to extend or modify status output formatting without touching daemon code
- Other commands continue to work as before with explicit `pipeToStdout()` calls

https://claude.ai/code/session_01Atpc7SdHY1FwGiMUyjXAMB