### PR TITLE
readme: Clarify environment variable usage in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,14 @@ export default defineConfig({
 
 ## Environment Variables
 
-dev-process-manager automatically loads environment variables from the following files in the project root, in order:
+dev-process-manager loads environment variables from the following files in the project root, in order:
 
 1. `.env` — shared defaults, typically committed to version control
 2. `.env.local` — local overrides, typically added to `.gitignore`
 
 Values defined in `.env.local` take precedence over those in `.env`. Variable expansion (e.g. `$OTHER_VAR`) is supported in both files.
+
+These variables are only used for substitution within `waitOn` resources (e.g. `tcp:$POSTGRESQL_PORT`). They are **not** passed to the script processes — scripts inherit the daemon's environment.
 
 ## Commands
 

--- a/src/dev-pm.e2e.test.ts
+++ b/src/dev-pm.e2e.test.ts
@@ -149,6 +149,34 @@ describe("dev-pm e2e", () => {
         expect(logs).toContain("19876");
     }, 30000);
 
+    it("does NOT pass .env variables to the script process", async () => {
+        // .env defines a variable that the script tries to read
+        writeFileSync(resolve(tmpDir, ".env"), "SCRIPT_ENV_VAR=from-dotenv\n");
+
+        // Script prints the value of SCRIPT_ENV_VAR, then stays alive
+        writeFileSync(
+            resolve(tmpDir, "dev-pm.config.mjs"),
+            `export default {
+    scripts: [
+        { name: "test-script", script: 'node -e "console.log(\\'SCRIPT_ENV_VAR=[\\' + (process.env.SCRIPT_ENV_VAR ?? \\'\\') + \\']\\'); setInterval(() => {}, 1000)"' },
+    ],
+};
+`,
+        );
+
+        await runDevPm(["start", "test-script"], tmpDir);
+        await new Promise((r) => setTimeout(r, 1000));
+
+        const status = stripAnsi(await runDevPm(["status"], tmpDir));
+        expect(status).toContain("test-script");
+        expect(status).toContain("Running");
+
+        // The script ran (marker present) but the .env value was NOT injected
+        const logs = stripAnsi(await runDevPm(["logs", "-n", "10", "test-script"], tmpDir));
+        expect(logs).toContain("SCRIPT_ENV_VAR=[]");
+        expect(logs).not.toContain("from-dotenv");
+    }, 30000);
+
     it("works from a subdirectory of the config file", async () => {
         const subDir = resolve(tmpDir, "packages", "app");
         mkdirSync(subDir, { recursive: true });


### PR DESCRIPTION
## Description

The README documentation for environment variables was unclear about how loaded variables are used. Users might assume that environment variables loaded from `.env` and `.env.local` are passed to script processes, which is not the case.

This change clarifies that environment variables are only used for substitution within `waitOn` resources (e.g., `tcp:$POSTGRESQL_PORT`) and are **not** passed to the script processes themselves — scripts inherit the daemon's environment instead.

This changed in https://github.com/vivid-planet/dev-process-manager/pull/97 but readme was not updated

https://claude.ai/code/session_01AWTnJDynNugZ32UqtbAfwB