### PR TITLE
Change package name to dev-process-manager

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [],

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Publish Canary release
         run: |
           echo --- > .changeset/canary.md
-          echo '"@comet/dev-process-manager": patch' >> .changeset/canary.md
+          echo '"dev-process-manager": patch' >> .changeset/canary.md
           echo --- >> .changeset/canary.md
           echo >> .changeset/canary.md
           echo fake change to always get a canary release >> .changeset/canary.md

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# @comet/dev-process-manager
+# dev-process-manager
 
 dev-process-manager is a Node.js process manager for local development environments that need multiple processes. It can be easily integrated into existing Node.js projects.
 
 ## Installation
 
 ```console
-$ npm install @comet/dev-process-manager
+$ npm install dev-process-manager
 ```
 
 Recommended Alias:
@@ -22,7 +22,7 @@ This file defines all available scripts, which should be started by dev-process-
 ### dev-pm.config.ts
 
 ```typescript
-import { defineConfig } from '@comet/dev-process-manager';
+import { defineConfig } from 'dev-process-manager';
 
 export default defineConfig({
     scripts: [

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # dev-process-manager documentation site
 
 This directory contains the [Docusaurus](https://docusaurus.io/) website for
-`@comet/dev-process-manager`.
+`dev-process-manager`.
 
 ## Local development
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -14,7 +14,7 @@ The file must have a **default export** containing a config object with a `scrip
 array. Using `defineConfig` gives you full type checking and autocompletion:
 
 ```typescript title="dev-pm.config.ts"
-import { defineConfig } from "@comet/dev-process-manager";
+import { defineConfig } from "dev-process-manager";
 
 export default defineConfig({
     scripts: [

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -14,7 +14,7 @@ at your project root.
 The smallest useful config — an API and an admin dev server.
 
 ```typescript title="dev-pm.config.ts"
-import { defineConfig } from "@comet/dev-process-manager";
+import { defineConfig } from "dev-process-manager";
 
 export default defineConfig({
     scripts: [
@@ -35,7 +35,7 @@ The API waits for Postgres to accept connections and for a shared package to be 
 before it starts.
 
 ```typescript title="dev-pm.config.ts"
-import { defineConfig } from "@comet/dev-process-manager";
+import { defineConfig } from "dev-process-manager";
 
 export default defineConfig({
     scripts: [
@@ -65,7 +65,7 @@ POSTGRESQL_PORT=5432
 ```
 
 ```typescript title="dev-pm.config.ts"
-import { defineConfig } from "@comet/dev-process-manager";
+import { defineConfig } from "dev-process-manager";
 
 export default defineConfig({
     scripts: [
@@ -84,7 +84,7 @@ Organize a larger stack into groups so you can start slices of it, and add alias
 convenience.
 
 ```typescript title="dev-pm.config.ts"
-import { defineConfig } from "@comet/dev-process-manager";
+import { defineConfig } from "dev-process-manager";
 
 export default defineConfig({
     scripts: [
@@ -127,7 +127,7 @@ dpm status -i 2          # watch the whole stack refresh every 2s
 Give one process its own environment values.
 
 ```typescript title="dev-pm.config.ts"
-import { defineConfig } from "@comet/dev-process-manager";
+import { defineConfig } from "dev-process-manager";
 
 export default defineConfig({
     scripts: [
@@ -148,7 +148,7 @@ export default defineConfig({
 A more complete example bringing several of the features together.
 
 ```typescript title="dev-pm.config.ts"
-import { defineConfig } from "@comet/dev-process-manager";
+import { defineConfig } from "dev-process-manager";
 
 export default defineConfig({
     scripts: [

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -16,7 +16,7 @@ This guide takes you from zero to a running multi-process dev environment.
 ## 1. Install
 
 ```bash
-npm install @comet/dev-process-manager
+npm install dev-process-manager
 ```
 
 ## 2. Add a convenient alias (recommended)
@@ -37,7 +37,7 @@ Add a `dev-pm.config.ts` file to your project root. It lists every process
 dev-process-manager should manage:
 
 ```typescript title="dev-pm.config.ts"
-import { defineConfig } from "@comet/dev-process-manager";
+import { defineConfig } from "dev-process-manager";
 
 export default defineConfig({
     scripts: [

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -51,5 +51,5 @@ them at any time with `dpm logs`.
 :::note
 This project is developed and maintained by
 [Vivid Planet Software GmbH](https://www.vivid-planet.com/) and published on npm as
-[`@comet/dev-process-manager`](https://www.npmjs.com/package/@comet/dev-process-manager).
+[`dev-process-manager`](https://www.npmjs.com/package/dev-process-manager).
 :::

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -72,7 +72,7 @@ const config: Config = {
                     position: "left",
                 },
                 {
-                    href: "https://www.npmjs.com/package/@comet/dev-process-manager",
+                    href: "https://www.npmjs.com/package/dev-process-manager",
                     label: "npm",
                     position: "right",
                 },
@@ -106,7 +106,7 @@ const config: Config = {
                     title: "More",
                     items: [
                         { label: "GitHub", href: "https://github.com/vivid-planet/dev-process-manager" },
-                        { label: "npm", href: "https://www.npmjs.com/package/@comet/dev-process-manager" },
+                        { label: "npm", href: "https://www.npmjs.com/package/dev-process-manager" },
                         { label: "Vivid Planet", href: "https://www.vivid-planet.com/" },
                     ],
                 },

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "@comet/dev-process-manager-docs",
+    "name": "dev-process-manager-docs",
     "version": "0.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "@comet/dev-process-manager-docs",
+            "name": "dev-process-manager-docs",
             "version": "0.0.0",
             "dependencies": {
                 "@docusaurus/core": "^3.9.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@comet/dev-process-manager-docs",
+    "name": "dev-process-manager-docs",
     "version": "0.0.0",
     "private": true,
     "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-    "name": "@comet/dev-process-manager",
-    "version": "3.1.0",
+    "name": "dev-process-manager",
+    "version": "1.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "@comet/dev-process-manager",
-            "version": "3.1.0",
+            "name": "dev-process-manager",
+            "version": "1.0.0",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "cli-table3": "^0.6.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "@comet/dev-process-manager",
+    "name": "dev-process-manager",
     "license": "BSD-2-Clause",
-    "version": "3.2.0",
+    "version": "1.0.0",
     "exports": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "bin": {


### PR DESCRIPTION
Remove the `@comet` scope from the package and reset the version to 1.0.0. We decided to _not_ publish it as `@dextinity/dev-process-manager` to demonstrate that the dev-process-manager can be used outside Comet/Dextinity.

https://claude.ai/code/session_014navz5peqWxPj6nHQB9KF5