### PR TITLE
Add version command to daemon

### DIFF
--- a/src/commands/start-daemon.command.ts
+++ b/src/commands/start-daemon.command.ts
@@ -1,7 +1,8 @@
 import colors from "colors";
-import { existsSync, watchFile } from "fs";
+import { existsSync, readFileSync, watchFile } from "fs";
 import { createServer, type Server } from "net";
-import { dirname } from "path";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
 
 import { logsDaemonCommand } from "../daemon-command/logs.daemon-command.js";
 import { restartDaemonCommand } from "../daemon-command/restart.daemon-command.js";
@@ -86,6 +87,11 @@ export const startDaemon = async (): Promise<void> => {
                 statusDaemonCommand(daemon, s, names);
             } else if (cmd == "shutdown") {
                 shutdownDaemonCommand(daemon, s);
+            } else if (cmd == "version") {
+                const __dirname = dirname(fileURLToPath(import.meta.url));
+                const { version } = JSON.parse(readFileSync(resolve(__dirname, "../../package.json"), "utf-8"));
+                s.write(`${JSON.stringify({ version })}\n`);
+                s.end();
             } else {
                 s.write(`unknown command ${cmd}`);
                 s.end();


### PR DESCRIPTION
## Description

Add a new `version` command to the daemon that allows clients to query the package version. This enables external tools and clients to programmatically check the daemon's version without needing to parse other outputs or access the filesystem directly.

The command reads the version from `package.json` and returns it as a JSON response, consistent with the daemon's existing command response format.

in preparation for #177 where we need to query the version

https://claude.ai/code/session_01HvmQcsv8ncXZ6E5KW4H6V8