### PR TITLE
Update dependencies to latest minor/patch versions

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,16 +9,16 @@
             "version": "0.0.0",
             "dependencies": {
                 "@docusaurus/core": "^3.9.2",
-                "@docusaurus/preset-classic": "^3.9.2",
-                "@mdx-js/react": "^3.0.0",
-                "clsx": "^2.0.0",
-                "prism-react-renderer": "^2.3.0",
-                "react": "^18.0.0",
-                "react-dom": "^18.0.0"
+                "@docusaurus/preset-classic": "^3.10.2",
+                "@mdx-js/react": "^3.1.1",
+                "clsx": "^2.1.1",
+                "prism-react-renderer": "^2.4.1",
+                "react": "^18.3.1",
+                "react-dom": "^18.3.1"
             },
             "devDependencies": {
                 "@docusaurus/module-type-aliases": "^3.9.2",
-                "@docusaurus/tsconfig": "^3.9.2",
+                "@docusaurus/tsconfig": "^3.10.2",
                 "@docusaurus/types": "^3.9.2",
                 "typescript": "~5.6.2"
             },
@@ -26,16 +26,31 @@
                 "node": ">=18.0"
             }
         },
-        "node_modules/@algolia/abtesting": {
-            "version": "1.21.2",
-            "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.21.2.tgz",
-            "integrity": "sha512-uXj0rgk30EpsKvOpuS+R+1XFDrnm56hED1Lz56e8uBkZdKCxw99LS2U8eXBqAHYU8kpkbsnV1GC8velBG070Hg==",
+        "node_modules/@11ty/gray-matter": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@11ty/gray-matter/-/gray-matter-1.0.0.tgz",
+            "integrity": "sha512-7mJJl+wf1AByoT0PknQiQfOPnVNT4fevGrUBVWO4HXsnYn1aQPyRyrELYrNUFleUBM++KzMKN6QaxHPk0t/6/g==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "js-yaml": "^4.1.0",
+                "kind-of": "^6.0.3",
+                "section-matter": "^1.0.0",
+                "strip-bom-string": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=11"
+            }
+        },
+        "node_modules/@algolia/abtesting": {
+            "version": "1.22.0",
+            "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.22.0.tgz",
+            "integrity": "sha512-BFR6zNowNKcY7Ou7TaJc9QWexES4YKPbmf/OTFofpdsdhz4x6q0lbxp3duO0EHnyrN7rE4ba/TSXuY+BDGu4+g==",
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/client-common": "5.56.0",
+                "@algolia/requester-browser-xhr": "5.56.0",
+                "@algolia/requester-fetch": "5.56.0",
+                "@algolia/requester-node-http": "5.56.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
@@ -74,99 +89,99 @@
             }
         },
         "node_modules/@algolia/client-abtesting": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.55.2.tgz",
-            "integrity": "sha512-y7Epol8HcjlBxKXHhyhfFPFhm78B3P6x9cCbCyGTdxjsdVCptXCy5hpkZWxjGpnaLHvWsHS4QRF0TiBOLst2xg==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.56.0.tgz",
+            "integrity": "sha512-7r4Z3NC7yU1oAQVWJNA2HX7tX481F3pJvCGyLIXiTdBcthz4Q/o21jwcMYDFkuI92UWTNBQQmHYgwHo1zS5dzg==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "@algolia/client-common": "5.56.0",
+                "@algolia/requester-browser-xhr": "5.56.0",
+                "@algolia/requester-fetch": "5.56.0",
+                "@algolia/requester-node-http": "5.56.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-analytics": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.55.2.tgz",
-            "integrity": "sha512-8Pxj2VVmpM2d+UZufnlTq7T1QIcYPVugLV5XC50PnHsV5uRM9CSoYkg2Y+CwqwRk2La0xK5QsfZ0obIU+9XftQ==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.56.0.tgz",
+            "integrity": "sha512-avmjXQSq+jadFO8Xl2em05/uQdQnEmHsJyOAdVbZkmVgpMfxL12aJwVVfGNwYr9nulcpuJN1X0lTaQ5wxuNGcA==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "@algolia/client-common": "5.56.0",
+                "@algolia/requester-browser-xhr": "5.56.0",
+                "@algolia/requester-fetch": "5.56.0",
+                "@algolia/requester-node-http": "5.56.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-common": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.55.2.tgz",
-            "integrity": "sha512-9L4IpIYUqA63a7sw1trnHQGUvwiAjKz67nsgDnal98JGAc7wyposRb0Iag+eiMuyzFFaSHLe2/rGyIo+PafRBA==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.56.0.tgz",
+            "integrity": "sha512-v2TPStUhY//ripPjIVclZ8AWc7DEGooXULZGFlFu37zNatgHjw34oZZ+OSbbc/YHO+xZwPl62I1k8xH1m4S2eg==",
             "license": "MIT",
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-insights": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.55.2.tgz",
-            "integrity": "sha512-ZBm2ytY5EHFcj+kjNsXxMNO/TGlOHe2fBFXGKHJOM1bk1rAy4o2YI+d9oV/w/jrqx44pvJMJlc8X6vKnCuDgUQ==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.56.0.tgz",
+            "integrity": "sha512-P0ehROpM4Sem3Sqo5x2cKPgj67D3G3jy0rh1Amwkcvsfr6tkvIcdCmerieanqTF7NxUMPNFLkpIFeMO8Rpa50w==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "@algolia/client-common": "5.56.0",
+                "@algolia/requester-browser-xhr": "5.56.0",
+                "@algolia/requester-fetch": "5.56.0",
+                "@algolia/requester-node-http": "5.56.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-personalization": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.55.2.tgz",
-            "integrity": "sha512-3FGVW/jDk7sdYwqa2NKnF/qXWcttc4bvGrwNbvqz3VoWSRv42CNvRk+3Y9QJFIUf1vY50hAuVWUoFKdyc8vaXA==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.56.0.tgz",
+            "integrity": "sha512-SXK3Vn3WVxyzbm31oePZBJkp1wpOyuWdd4B/Pv7n0aXDxmeSWhC1R1FC1517mMrFAIaPH4Rt0x6RUe7ZNjz8FA==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "@algolia/client-common": "5.56.0",
+                "@algolia/requester-browser-xhr": "5.56.0",
+                "@algolia/requester-fetch": "5.56.0",
+                "@algolia/requester-node-http": "5.56.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-query-suggestions": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.55.2.tgz",
-            "integrity": "sha512-JsG8LovDAYul5t8e533tZ3O1uZILxso5zsTtB7ONc5RJ8ACdTxAAC/jaOnsBNYb+x+STP7fzx/Iro55v5DNgoQ==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.56.0.tgz",
+            "integrity": "sha512-5+ZdX8garFnmycnZgKhtXHePEaLj5zqDxI/0lkhhluzCcvTn0/PvvTirTg8hHYetQHvn7GDyeAiqTAieMvMW4A==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "@algolia/client-common": "5.56.0",
+                "@algolia/requester-browser-xhr": "5.56.0",
+                "@algolia/requester-fetch": "5.56.0",
+                "@algolia/requester-node-http": "5.56.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-search": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.55.2.tgz",
-            "integrity": "sha512-5wDnoIfC75zJ2MSHv5SSzTlRL2z7jQMbqQ5jrzottuq2p3oBObv8pD/JpXWu8pRaimaxNr3/Bs/KZIGVXxJ7hg==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.56.0.tgz",
+            "integrity": "sha512-+mKUdYvqOi0BcvpAEyCEw49vSBptufIcfibtHz2bdr1pI789M46Yt0uQEk/sxtK3teh71OQvVFHaTDzShUWewQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "@algolia/client-common": "5.56.0",
+                "@algolia/requester-browser-xhr": "5.56.0",
+                "@algolia/requester-fetch": "5.56.0",
+                "@algolia/requester-node-http": "5.56.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
@@ -179,81 +194,81 @@
             "license": "MIT"
         },
         "node_modules/@algolia/ingestion": {
-            "version": "1.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.55.2.tgz",
-            "integrity": "sha512-da+SC6ikpza98W7C5ChsKEQDvZc8PQLQ0sxmQ5yMRsHpdD3iPKnclJA6ViB5Nr5T9qOX+IDswC6AyqY4V3rtug==",
+            "version": "1.56.0",
+            "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.56.0.tgz",
+            "integrity": "sha512-9g/zj+AZx5moFcdFIrYQoVrueXivjUcc3MQHtCYT8WhIuk1lUh1AyEhvJCS0XBZld09cLvd1AZ3BvDBpVpX2UA==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "@algolia/client-common": "5.56.0",
+                "@algolia/requester-browser-xhr": "5.56.0",
+                "@algolia/requester-fetch": "5.56.0",
+                "@algolia/requester-node-http": "5.56.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/monitoring": {
-            "version": "1.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.55.2.tgz",
-            "integrity": "sha512-Y8kEcPqCiIEeaGv83l9RRA09mfYECqAJHNnOyEtZc9UirI6XBMUyFVss/sSeYUiV/Lf30hkbWcl00V1uXsf86Q==",
+            "version": "1.56.0",
+            "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.56.0.tgz",
+            "integrity": "sha512-Qf3Sr6f9A9uxCZUf3MXS0d2b877uYzEB5yxqpVGXAhcJnBCQjrRRon0KvefpGkxy+BshrIJs96OUoMtGqXTFDA==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "@algolia/client-common": "5.56.0",
+                "@algolia/requester-browser-xhr": "5.56.0",
+                "@algolia/requester-fetch": "5.56.0",
+                "@algolia/requester-node-http": "5.56.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/recommend": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.55.2.tgz",
-            "integrity": "sha512-5zmobuCQqFZkx+84Nt+suL7vo6jTh2CfAs2ndDSeTS2QHvnzP8YEEGWtWftjyACI0cK/FuH8urWwCHP+d2j8TA==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.56.0.tgz",
+            "integrity": "sha512-GXWG1rWc5wu8hY4N33Y3b6ernY6sAdAvmKWN/zHAiACOx40WnpG0TVX5YazCAr/9gOYGInSiM2A0y2jy2xbiDA==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "@algolia/client-common": "5.56.0",
+                "@algolia/requester-browser-xhr": "5.56.0",
+                "@algolia/requester-fetch": "5.56.0",
+                "@algolia/requester-node-http": "5.56.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-browser-xhr": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.55.2.tgz",
-            "integrity": "sha512-qnGUUuWG66dRMnr33owLsrYIh9fHVxtU4R2rd3SpneAHuoAUcGbDOWNrj05glVU6M8yOqo9gQ22K8zpz0I8Xpg==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.56.0.tgz",
+            "integrity": "sha512-7t24cBxaInS3mZb7ddEaZT/tp6q+/aR4YttsQVyP1/i+LmwPR34atO35KjaLFCcRVrlP7sYOAqkCfg6lIRB+ew==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2"
+                "@algolia/client-common": "5.56.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-fetch": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.55.2.tgz",
-            "integrity": "sha512-lKZ5uhafMvR7dWCJEyuaeyZitid1I3ICx+k0vGf5x/ktdIQvc7bndCiOPpmIDqUmN26FE3jTehkAzSqee95G2Q==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.56.0.tgz",
+            "integrity": "sha512-R7ePHgVYmDFjZpvrsVAfbDz/d4RxKAYZ5/vgLfIsCVRZRryjWl/3INOxpOICzitehQ5FjNtNjcLQTrmHPTcHBQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2"
+                "@algolia/client-common": "5.56.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-node-http": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.55.2.tgz",
-            "integrity": "sha512-Zc90xvKWUvxcNicvvTO9Pr/hT2TAnkixOIzJm/KMj5Ptm2pKjk71ngTsdkbRtJQvhZ2Kr9N1YdIjLrNHB5P2xw==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.56.0.tgz",
+            "integrity": "sha512-PIOUXlSnrqM0S+WOgDRb4RzotydJH7ZoT6tOyL7tAO7qJOfvX5wsEW8Pe+PMKMwvuI4/gIyK9cg2H7lJXqnc4Q==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2"
+                "@algolia/client-common": "5.56.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
@@ -3313,9 +3328,9 @@
             }
         },
         "node_modules/@docsearch/core": {
-            "version": "4.6.3",
-            "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.6.3.tgz",
-            "integrity": "sha512-rUOujwIpxJRgD7+kicVsI3D5sqBvdiRTquzWBpTEXZs8ZXfGbfzpus5HqumaNYTppN2HvH8E2yNuRwYdHJeOlA==",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.7.0.tgz",
+            "integrity": "sha512-p/9xVKmPDj3FPvMfPf5naVO3Ej8SCbcUugGvx1+8GgkuBNbqxqN2Irx3WLBv8VY0jH7XpRwKWdlmjXLZsmTLsg==",
             "license": "MIT",
             "peerDependencies": {
                 "@types/react": ">= 16.8.0 < 20.0.0",
@@ -3335,20 +3350,20 @@
             }
         },
         "node_modules/@docsearch/css": {
-            "version": "4.6.3",
-            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.3.tgz",
-            "integrity": "sha512-nlOwcXcsNAptQl4vlL4MA78qNJKO0Qlds5GuBjCoePgkebTXLSf8Qt1oyZ3YBshYupKXG9VRGEsk1zr23d+bzQ==",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.7.0.tgz",
+            "integrity": "sha512-Sk5xkdRFeE7PeWjG9l4AfTwdvMfr9wHiwNNCpHXT4v4SNyNMKdHGvEILc31BgaVFGDDNbv5u/a73tofRiwbEZw==",
             "license": "MIT"
         },
         "node_modules/@docsearch/react": {
-            "version": "4.6.3",
-            "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.6.3.tgz",
-            "integrity": "sha512-Bg2wdDsoQVlNCcEKuEJAU04tvHCqgx8rIu+uIoM4pRtcx3TBKJuXutJik3LTA8LRc9YEyHkrYUrmcC0D7BYf+g==",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.7.0.tgz",
+            "integrity": "sha512-x6oedjJ8O8/pIDBsMo5Orca3/6cQCz616/CwthVe68l43mqnj2lrJ9kFQITBqy8hMsS3nWeBWFoVO5dJ1DCFKA==",
             "license": "MIT",
             "dependencies": {
                 "@algolia/autocomplete-core": "1.19.2",
-                "@docsearch/core": "4.6.3",
-                "@docsearch/css": "4.6.3"
+                "@docsearch/core": "4.7.0",
+                "@docsearch/css": "4.7.0"
             },
             "peerDependencies": {
                 "@types/react": ">= 16.8.0 < 20.0.0",
@@ -3404,9 +3419,9 @@
             }
         },
         "node_modules/@docusaurus/babel": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.10.1.tgz",
-            "integrity": "sha512-DZzFO1K3v/GoEt1fx1DiYHF4en+PuhtQf1AkQJa5zu3CoeKSpr5cpQRUlz3jr0m44wyzmSXu9bVpfir+N4+8bg==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.10.2.tgz",
+            "integrity": "sha512-aJ1hpGyvfkte3dDAfNbWM4biW4yWZBVz7TIGLZP+v+tWOBgxX3e0N5ZIXHIvmfNNXTI77pcHUx3KmtOk05Ze3Q==",
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.25.9",
@@ -3418,8 +3433,8 @@
                 "@babel/preset-typescript": "^7.25.9",
                 "@babel/runtime": "^7.25.9",
                 "@babel/traverse": "^7.25.9",
-                "@docusaurus/logger": "3.10.1",
-                "@docusaurus/utils": "3.10.1",
+                "@docusaurus/logger": "3.10.2",
+                "@docusaurus/utils": "3.10.2",
                 "babel-plugin-dynamic-import-node": "^2.3.3",
                 "fs-extra": "^11.1.1",
                 "tslib": "^2.6.0"
@@ -3429,17 +3444,17 @@
             }
         },
         "node_modules/@docusaurus/bundler": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.10.1.tgz",
-            "integrity": "sha512-HIqQPvbqnnQRe4NsBd1774KRarjXqS6wHsWELtyuSs1gCfvixJO2jUGH/OEBtr1Gvzpw+ze5CjGMvSJ8UE1KUw==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.10.2.tgz",
+            "integrity": "sha512-i0ZNcy0f0WhaOlYVgzLsWhIoEXO9kS3HRoKPtgE6vQtZUq7arKZaYdNBudr3mqCmd+TyOkwtwfHgs1ENj07r5g==",
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.25.9",
-                "@docusaurus/babel": "3.10.1",
-                "@docusaurus/cssnano-preset": "3.10.1",
-                "@docusaurus/logger": "3.10.1",
-                "@docusaurus/types": "3.10.1",
-                "@docusaurus/utils": "3.10.1",
+                "@docusaurus/babel": "3.10.2",
+                "@docusaurus/cssnano-preset": "3.10.2",
+                "@docusaurus/logger": "3.10.2",
+                "@docusaurus/types": "3.10.2",
+                "@docusaurus/utils": "3.10.2",
                 "babel-loader": "^9.2.1",
                 "clean-css": "^5.3.3",
                 "copy-webpack-plugin": "^11.0.0",
@@ -3472,18 +3487,18 @@
             }
         },
         "node_modules/@docusaurus/core": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.10.1.tgz",
-            "integrity": "sha512-3pf2fXXw0eVk8WnC3T4LIigRDupcpvngpKo9Vy7mYyBhuddc0klDUuZAIfzMoK6z05pdlk6EFC/vBSX43+1O5w==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.10.2.tgz",
+            "integrity": "sha512-EYByj6nk+aD9KeVxV6Hmo2/nAAT79P21Y82ycTBOBtrmqilloIbIEhgL2/8Xpt2Jz/pgNqHAwyusOGwmbKeJmA==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/babel": "3.10.1",
-                "@docusaurus/bundler": "3.10.1",
-                "@docusaurus/logger": "3.10.1",
-                "@docusaurus/mdx-loader": "3.10.1",
-                "@docusaurus/utils": "3.10.1",
-                "@docusaurus/utils-common": "3.10.1",
-                "@docusaurus/utils-validation": "3.10.1",
+                "@docusaurus/babel": "3.10.2",
+                "@docusaurus/bundler": "3.10.2",
+                "@docusaurus/logger": "3.10.2",
+                "@docusaurus/mdx-loader": "3.10.2",
+                "@docusaurus/utils": "3.10.2",
+                "@docusaurus/utils-common": "3.10.2",
+                "@docusaurus/utils-validation": "3.10.2",
                 "boxen": "^6.2.1",
                 "chalk": "^4.1.2",
                 "chokidar": "^3.5.3",
@@ -3491,7 +3506,7 @@
                 "combine-promises": "^1.1.0",
                 "commander": "^5.1.0",
                 "core-js": "^3.31.1",
-                "detect-port": "^1.5.1",
+                "detect-port": "^2.1.0",
                 "escape-html": "^1.0.3",
                 "eta": "^2.2.0",
                 "eval": "^0.1.8",
@@ -3539,9 +3554,9 @@
             }
         },
         "node_modules/@docusaurus/cssnano-preset": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.10.1.tgz",
-            "integrity": "sha512-eNfHGcTKCSq6xmcavAkX3RRclHaE2xRCMParlDXLdXVP01/a2e/jKXMj/0ULnLFQSNwwuI62L0Ge8J+nZsR7UQ==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.10.2.tgz",
+            "integrity": "sha512-4gCnHRbJLTloiwfvFAa92tgb2gI4KYhvjfQVYnEaiMO/EgvWfCo1LwytHXen+1oZAN0VAlS0JAPxp3MsvKDa3A==",
             "license": "MIT",
             "dependencies": {
                 "cssnano-preset-advanced": "^6.1.2",
@@ -3554,9 +3569,9 @@
             }
         },
         "node_modules/@docusaurus/logger": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.1.tgz",
-            "integrity": "sha512-oPjNFnfJsRCkePVjkGrxWGq4MvJKRQT0r9jOP0eRBTZ7Wr9FAbzdP/Gjs0I2Ss6YRkPoEgygKG112OkE6skvJw==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.2.tgz",
+            "integrity": "sha512-gSEwqtPfCAnC3ZSJY6xL7tcIfgg0vFD39jbv93eakuweyvO2864xR0K+kmKwBhkTCtWRNjuGGnb5rdmkD/ndqw==",
             "license": "MIT",
             "dependencies": {
                 "chalk": "^4.1.2",
@@ -3567,14 +3582,14 @@
             }
         },
         "node_modules/@docusaurus/mdx-loader": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.10.1.tgz",
-            "integrity": "sha512-GRmeb/wQ+iXRrFwcHBfgQhrJxGElgCsoTWZYDhccjsZVne1p8MK/EpQVIloXttz76TCe78kKD5AEG9n1xc1oxQ==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.10.2.tgz",
+            "integrity": "sha512-9Fd4V/SFjfrVQ0JH5EN0+iPWyFunvTeQE3gfyFeetqPaXMP0OylIjOw16dCuXG4NZJrYdBqwzjh18/h3gRi47w==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/logger": "3.10.1",
-                "@docusaurus/utils": "3.10.1",
-                "@docusaurus/utils-validation": "3.10.1",
+                "@docusaurus/logger": "3.10.2",
+                "@docusaurus/utils": "3.10.2",
+                "@docusaurus/utils-validation": "3.10.2",
                 "@mdx-js/mdx": "^3.0.0",
                 "@slorber/remark-comment": "^1.0.0",
                 "escape-html": "^1.0.3",
@@ -3606,12 +3621,12 @@
             }
         },
         "node_modules/@docusaurus/module-type-aliases": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.1.tgz",
-            "integrity": "sha512-YoOZKUdGlp8xSYhuAkGdSo5Ydkbq4V4eK3sD8v0a2hloxCWdQbNBhkc+Ko9QyjpESc0BYcIGM5iHVAy5hdFV6w==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.2.tgz",
+            "integrity": "sha512-h/I5e4jaAhDHW4vaLENi1i2hnOEnXY1t9R+nnRTbgUl7ymVRzN/HF7dDfj8rKYGj8gfIge+Ef+iYRAMtbGvsrQ==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/types": "3.10.1",
+                "@docusaurus/types": "3.10.2",
                 "@types/history": "^4.7.11",
                 "@types/react": "*",
                 "@types/react-router-config": "*",
@@ -3625,19 +3640,19 @@
             }
         },
         "node_modules/@docusaurus/plugin-content-blog": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.10.1.tgz",
-            "integrity": "sha512-mmkgE6Q2+K74tnkou7tXlpDLvoCU/qkSa2GSQ3XUiHWvcebCoDQzS670RR3tO8PmaWlIyWWISYWzZLuMfxunRA==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.10.2.tgz",
+            "integrity": "sha512-0cbEnNKf0InmLkhj/+nVRmqEnWEoOE8Mh+2x1qOXI0qYpCnphq4RXknVJ8BvybKRXqYVvbmdMfiJSup+k4tm5w==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.10.1",
-                "@docusaurus/logger": "3.10.1",
-                "@docusaurus/mdx-loader": "3.10.1",
-                "@docusaurus/theme-common": "3.10.1",
-                "@docusaurus/types": "3.10.1",
-                "@docusaurus/utils": "3.10.1",
-                "@docusaurus/utils-common": "3.10.1",
-                "@docusaurus/utils-validation": "3.10.1",
+                "@docusaurus/core": "3.10.2",
+                "@docusaurus/logger": "3.10.2",
+                "@docusaurus/mdx-loader": "3.10.2",
+                "@docusaurus/theme-common": "3.10.2",
+                "@docusaurus/types": "3.10.2",
+                "@docusaurus/utils": "3.10.2",
+                "@docusaurus/utils-common": "3.10.2",
+                "@docusaurus/utils-validation": "3.10.2",
                 "cheerio": "1.0.0-rc.12",
                 "combine-promises": "^1.1.0",
                 "feed": "^4.2.2",
@@ -3660,20 +3675,20 @@
             }
         },
         "node_modules/@docusaurus/plugin-content-docs": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.1.tgz",
-            "integrity": "sha512-2jRVrtzjf8LClGTHQlwlwuD3wQXRx3WEoF7XUarJ8Ou+0onV+SLtejsyfY9JLpfUh9hPhXM4pbBGkyAY4Bi3HQ==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.2.tgz",
+            "integrity": "sha512-Sqwl4FPoZBDrlY8I2VU2H8O0M91CHp9T8ToMSkTZmjvHCif+1laqfXi6sTk8IfyVS/trN5yNjcWd1bFsGB6W5Q==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.10.1",
-                "@docusaurus/logger": "3.10.1",
-                "@docusaurus/mdx-loader": "3.10.1",
-                "@docusaurus/module-type-aliases": "3.10.1",
-                "@docusaurus/theme-common": "3.10.1",
-                "@docusaurus/types": "3.10.1",
-                "@docusaurus/utils": "3.10.1",
-                "@docusaurus/utils-common": "3.10.1",
-                "@docusaurus/utils-validation": "3.10.1",
+                "@docusaurus/core": "3.10.2",
+                "@docusaurus/logger": "3.10.2",
+                "@docusaurus/mdx-loader": "3.10.2",
+                "@docusaurus/module-type-aliases": "3.10.2",
+                "@docusaurus/theme-common": "3.10.2",
+                "@docusaurus/types": "3.10.2",
+                "@docusaurus/utils": "3.10.2",
+                "@docusaurus/utils-common": "3.10.2",
+                "@docusaurus/utils-validation": "3.10.2",
                 "@types/react-router-config": "^5.0.7",
                 "combine-promises": "^1.1.0",
                 "fs-extra": "^11.1.1",
@@ -3693,16 +3708,16 @@
             }
         },
         "node_modules/@docusaurus/plugin-content-pages": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.10.1.tgz",
-            "integrity": "sha512-huJpaRPMl42nsFwuCXvV8bVDj2MazuwRJIUylI/RSlmZeJssVoZXeCjVf1y+1Drtpa9SKcdGn8yoJ76IRJijtw==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.10.2.tgz",
+            "integrity": "sha512-h5R12sZ/vV9EPiVjvIl9YFCOwkpwXes7dQMYt3EvP6Pphu4amHxxTqWxf08Fl5DR8h+oZMbWpFTNw5vKEYfvzQ==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.10.1",
-                "@docusaurus/mdx-loader": "3.10.1",
-                "@docusaurus/types": "3.10.1",
-                "@docusaurus/utils": "3.10.1",
-                "@docusaurus/utils-validation": "3.10.1",
+                "@docusaurus/core": "3.10.2",
+                "@docusaurus/mdx-loader": "3.10.2",
+                "@docusaurus/types": "3.10.2",
+                "@docusaurus/utils": "3.10.2",
+                "@docusaurus/utils-validation": "3.10.2",
                 "fs-extra": "^11.1.1",
                 "tslib": "^2.6.0",
                 "webpack": "^5.88.1"
@@ -3716,15 +3731,15 @@
             }
         },
         "node_modules/@docusaurus/plugin-css-cascade-layers": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.10.1.tgz",
-            "integrity": "sha512-r//fn+MNHkE1wCof8T29VAQezt1enGCpsFxoziBbvLgBM4JfXN2P3rxrBaavHmvLvm7lYkpJeitcDthwnmWCTw==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.10.2.tgz",
+            "integrity": "sha512-UkdvQby5OQUKWrw3lLnSTJXQ6VETaUVTuPQX9AABtmFm5h+ifEBx1OQ+LN726Q4byuwBf2ElHkf4qU4hTxdvRg==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.10.1",
-                "@docusaurus/types": "3.10.1",
-                "@docusaurus/utils": "3.10.1",
-                "@docusaurus/utils-validation": "3.10.1",
+                "@docusaurus/core": "3.10.2",
+                "@docusaurus/types": "3.10.2",
+                "@docusaurus/utils": "3.10.2",
+                "@docusaurus/utils-validation": "3.10.2",
                 "tslib": "^2.6.0"
             },
             "engines": {
@@ -3732,14 +3747,14 @@
             }
         },
         "node_modules/@docusaurus/plugin-debug": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.10.1.tgz",
-            "integrity": "sha512-9KqOpKNfAyqGZykRb9LhIT/vyRF6sm/ykhjj/39JvaJahDS+jZJE0Z1Wfz9q3DUNDTMNN0Q7u/kk4rKKU+IJuA==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.10.2.tgz",
+            "integrity": "sha512-8vbZNOSCpnsT57EY6CgN7sgRVmx3KTYwO8Uvo2pbxOyb8tbqAwtT9SslqaQ41HbA1v1hpn5RP7u5s2KvRwAFpQ==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.10.1",
-                "@docusaurus/types": "3.10.1",
-                "@docusaurus/utils": "3.10.1",
+                "@docusaurus/core": "3.10.2",
+                "@docusaurus/types": "3.10.2",
+                "@docusaurus/utils": "3.10.2",
                 "fs-extra": "^11.1.1",
                 "react-json-view-lite": "^2.3.0",
                 "tslib": "^2.6.0"
@@ -3753,14 +3768,14 @@
             }
         },
         "node_modules/@docusaurus/plugin-google-analytics": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.10.1.tgz",
-            "integrity": "sha512-8o0P1KtmgdYQHH+oInitPpRWI0Of5XednAX4+DMhQNSmGSRNrsEEHg1ebv35m9AgRClfAytCJ5jA9KvcASTyuA==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.10.2.tgz",
+            "integrity": "sha512-kMHMBK9j4VAtgd5owwrRLRIi0EjkrpXlX7ePj1+y68XfVZV9I1T4S+koPDm+Hfw2TtnyHvh0uNrDvjz+DjQGVA==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.10.1",
-                "@docusaurus/types": "3.10.1",
-                "@docusaurus/utils-validation": "3.10.1",
+                "@docusaurus/core": "3.10.2",
+                "@docusaurus/types": "3.10.2",
+                "@docusaurus/utils-validation": "3.10.2",
                 "tslib": "^2.6.0"
             },
             "engines": {
@@ -3772,15 +3787,14 @@
             }
         },
         "node_modules/@docusaurus/plugin-google-gtag": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.10.1.tgz",
-            "integrity": "sha512-pu3xIUo5o/zCMLfUY9BO5KOwSH0zIsAGyFRPvXHayFSA5XIhCU/SFuB0g0ZNjFn9niZLCaNvoeAuOGFJZq0fdw==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.10.2.tgz",
+            "integrity": "sha512-Vt90nNFhtAChRe9+it1hcHFgFvETdSnOkL5Bma+p6E/yU2tAYrvvyk+gv+LJGM2ZUkyKuKXLRsZ2Lb0bO7+Vog==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.10.1",
-                "@docusaurus/types": "3.10.1",
-                "@docusaurus/utils-validation": "3.10.1",
-                "@types/gtag.js": "^0.0.20",
+                "@docusaurus/core": "3.10.2",
+                "@docusaurus/types": "3.10.2",
+                "@docusaurus/utils-validation": "3.10.2",
                 "tslib": "^2.6.0"
             },
             "engines": {
@@ -3792,14 +3806,14 @@
             }
         },
         "node_modules/@docusaurus/plugin-google-tag-manager": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.10.1.tgz",
-            "integrity": "sha512-f6fyGHiCm7kJHBtAisGQS5oNBnpnMTYQZxDXeVrnw/3zWU+LMA22pr6UHGYkBKDbN+qPC5QHG3NuOfzQLq3+Lw==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.10.2.tgz",
+            "integrity": "sha512-MLCffCldysi/R0nzJQP7ZWd0xAoGNnSTiVOo6TTR6mKVGFhE+/XArGe67ZcaZv1uytgQXoXs92VJrgVDrz80rQ==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.10.1",
-                "@docusaurus/types": "3.10.1",
-                "@docusaurus/utils-validation": "3.10.1",
+                "@docusaurus/core": "3.10.2",
+                "@docusaurus/types": "3.10.2",
+                "@docusaurus/utils-validation": "3.10.2",
                 "tslib": "^2.6.0"
             },
             "engines": {
@@ -3811,17 +3825,17 @@
             }
         },
         "node_modules/@docusaurus/plugin-sitemap": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.10.1.tgz",
-            "integrity": "sha512-C26MbmmqgdjkDq1htaZ3aD7LzEDKFWXfpyQpt0EOUThuq5nV77zDaedV20yHcVo9p+3ey9aZ4pbHA0D3QcZTzg==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.10.2.tgz",
+            "integrity": "sha512-PODkwg5XetLML3hU/3xpCKJUZ9cqExLaBnD/Fzzwj2VHogLeqnDisLIujae87zuze7T4mCm2A6KEqZkyiz07EQ==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.10.1",
-                "@docusaurus/logger": "3.10.1",
-                "@docusaurus/types": "3.10.1",
-                "@docusaurus/utils": "3.10.1",
-                "@docusaurus/utils-common": "3.10.1",
-                "@docusaurus/utils-validation": "3.10.1",
+                "@docusaurus/core": "3.10.2",
+                "@docusaurus/logger": "3.10.2",
+                "@docusaurus/types": "3.10.2",
+                "@docusaurus/utils": "3.10.2",
+                "@docusaurus/utils-common": "3.10.2",
+                "@docusaurus/utils-validation": "3.10.2",
                 "fs-extra": "^11.1.1",
                 "sitemap": "^7.1.1",
                 "tslib": "^2.6.0"
@@ -3835,15 +3849,15 @@
             }
         },
         "node_modules/@docusaurus/plugin-svgr": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.10.1.tgz",
-            "integrity": "sha512-6SFxsmjWFkVLDmBUvFK6i72QjUwqyQFe4Ovz+SUJophJjOyVG3ZZG5IQpBC/kX/Gfv1yWeU9nWauH6F6Q7QX/Q==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.10.2.tgz",
+            "integrity": "sha512-JgfT3jWM0TJ8Uw0cEcqxHpybngQY1vlBYpuuNO+gEh5iPh5Ar+vxq/u9CFrYsWeXy48BN7Db76Pzp2edNXUQ8A==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.10.1",
-                "@docusaurus/types": "3.10.1",
-                "@docusaurus/utils": "3.10.1",
-                "@docusaurus/utils-validation": "3.10.1",
+                "@docusaurus/core": "3.10.2",
+                "@docusaurus/types": "3.10.2",
+                "@docusaurus/utils": "3.10.2",
+                "@docusaurus/utils-validation": "3.10.2",
                 "@svgr/core": "8.1.0",
                 "@svgr/webpack": "^8.1.0",
                 "tslib": "^2.6.0",
@@ -3858,26 +3872,26 @@
             }
         },
         "node_modules/@docusaurus/preset-classic": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.10.1.tgz",
-            "integrity": "sha512-YO/FL8v1zmbxoTso6mjMz/RDjhaTJxb1UpFFTDdY5847LLDCeyYiYlrhyTbgN1RIN3xnkLKZ9Lj1x8hUzI4JOg==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.10.2.tgz",
+            "integrity": "sha512-a4B3VczmDl99zK0EufDQYomdJ186WDingjmDXxhN2PNPS9Ty/Y2M5CLFX1KQMRKqRTLiRDKfutzG5IY1FC/ceg==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.10.1",
-                "@docusaurus/plugin-content-blog": "3.10.1",
-                "@docusaurus/plugin-content-docs": "3.10.1",
-                "@docusaurus/plugin-content-pages": "3.10.1",
-                "@docusaurus/plugin-css-cascade-layers": "3.10.1",
-                "@docusaurus/plugin-debug": "3.10.1",
-                "@docusaurus/plugin-google-analytics": "3.10.1",
-                "@docusaurus/plugin-google-gtag": "3.10.1",
-                "@docusaurus/plugin-google-tag-manager": "3.10.1",
-                "@docusaurus/plugin-sitemap": "3.10.1",
-                "@docusaurus/plugin-svgr": "3.10.1",
-                "@docusaurus/theme-classic": "3.10.1",
-                "@docusaurus/theme-common": "3.10.1",
-                "@docusaurus/theme-search-algolia": "3.10.1",
-                "@docusaurus/types": "3.10.1"
+                "@docusaurus/core": "3.10.2",
+                "@docusaurus/plugin-content-blog": "3.10.2",
+                "@docusaurus/plugin-content-docs": "3.10.2",
+                "@docusaurus/plugin-content-pages": "3.10.2",
+                "@docusaurus/plugin-css-cascade-layers": "3.10.2",
+                "@docusaurus/plugin-debug": "3.10.2",
+                "@docusaurus/plugin-google-analytics": "3.10.2",
+                "@docusaurus/plugin-google-gtag": "3.10.2",
+                "@docusaurus/plugin-google-tag-manager": "3.10.2",
+                "@docusaurus/plugin-sitemap": "3.10.2",
+                "@docusaurus/plugin-svgr": "3.10.2",
+                "@docusaurus/theme-classic": "3.10.2",
+                "@docusaurus/theme-common": "3.10.2",
+                "@docusaurus/theme-search-algolia": "3.10.2",
+                "@docusaurus/types": "3.10.2"
             },
             "engines": {
                 "node": ">=20.0"
@@ -3888,24 +3902,24 @@
             }
         },
         "node_modules/@docusaurus/theme-classic": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.10.1.tgz",
-            "integrity": "sha512-VU1RK0qb2pab0si4r7HFK37cYco8VzqLj3u1PspVipSr/z/GPVKHO4/HXbnePqHoWDk8urjyGSeatH0NIMBM1A==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.10.2.tgz",
+            "integrity": "sha512-JqTSLQmqmA9uKWZsD5iwBGJ4JyKB4/yTw6PsSXVPRJG/6GAm/u+add9Iip+hvwP12/AnPNztrdxsI14NJW4KeA==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.10.1",
-                "@docusaurus/logger": "3.10.1",
-                "@docusaurus/mdx-loader": "3.10.1",
-                "@docusaurus/module-type-aliases": "3.10.1",
-                "@docusaurus/plugin-content-blog": "3.10.1",
-                "@docusaurus/plugin-content-docs": "3.10.1",
-                "@docusaurus/plugin-content-pages": "3.10.1",
-                "@docusaurus/theme-common": "3.10.1",
-                "@docusaurus/theme-translations": "3.10.1",
-                "@docusaurus/types": "3.10.1",
-                "@docusaurus/utils": "3.10.1",
-                "@docusaurus/utils-common": "3.10.1",
-                "@docusaurus/utils-validation": "3.10.1",
+                "@docusaurus/core": "3.10.2",
+                "@docusaurus/logger": "3.10.2",
+                "@docusaurus/mdx-loader": "3.10.2",
+                "@docusaurus/module-type-aliases": "3.10.2",
+                "@docusaurus/plugin-content-blog": "3.10.2",
+                "@docusaurus/plugin-content-docs": "3.10.2",
+                "@docusaurus/plugin-content-pages": "3.10.2",
+                "@docusaurus/theme-common": "3.10.2",
+                "@docusaurus/theme-translations": "3.10.2",
+                "@docusaurus/types": "3.10.2",
+                "@docusaurus/utils": "3.10.2",
+                "@docusaurus/utils-common": "3.10.2",
+                "@docusaurus/utils-validation": "3.10.2",
                 "@mdx-js/react": "^3.0.0",
                 "clsx": "^2.0.0",
                 "copy-text-to-clipboard": "^3.2.0",
@@ -3929,15 +3943,15 @@
             }
         },
         "node_modules/@docusaurus/theme-common": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.1.tgz",
-            "integrity": "sha512-0YtmIeoNo1fIw65LO8+/1dPgmDV86UmhMkow37gzjytuiCSQm9xob6PJy0L4kuQEMTLfUOGvkXvZr7GPrHquMA==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.2.tgz",
+            "integrity": "sha512-R9b/vMpK1yye6hNZTA6x/ivRv+at6GhxnXcxkpzCGzO1R1RwiquqiFg2wMFh6aqlJTpWRFKpFD2TzCDQcyOU0A==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/mdx-loader": "3.10.1",
-                "@docusaurus/module-type-aliases": "3.10.1",
-                "@docusaurus/utils": "3.10.1",
-                "@docusaurus/utils-common": "3.10.1",
+                "@docusaurus/mdx-loader": "3.10.2",
+                "@docusaurus/module-type-aliases": "3.10.2",
+                "@docusaurus/utils": "3.10.2",
+                "@docusaurus/utils-common": "3.10.2",
                 "@types/history": "^4.7.11",
                 "@types/react": "*",
                 "@types/react-router-config": "*",
@@ -3957,20 +3971,20 @@
             }
         },
         "node_modules/@docusaurus/theme-search-algolia": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.10.1.tgz",
-            "integrity": "sha512-OTaARARVZj2GvkJQjB+1jOIxntRaXea+G+fMsNqrZBAU1O1vJKDW22R7kECOHW27oJCLFN9HKaZeRrfAUyviug==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.10.2.tgz",
+            "integrity": "sha512-1msxllyhi/5m77JukXtp5UFnUAriwZIC1oJ7MTnpQpCwLTbclJi5BK5n28CTZuSXpQN2ewbbnqRgAhMM6c6ihg==",
             "license": "MIT",
             "dependencies": {
                 "@algolia/autocomplete-core": "^1.19.2",
                 "@docsearch/react": "^3.9.0 || ^4.3.2",
-                "@docusaurus/core": "3.10.1",
-                "@docusaurus/logger": "3.10.1",
-                "@docusaurus/plugin-content-docs": "3.10.1",
-                "@docusaurus/theme-common": "3.10.1",
-                "@docusaurus/theme-translations": "3.10.1",
-                "@docusaurus/utils": "3.10.1",
-                "@docusaurus/utils-validation": "3.10.1",
+                "@docusaurus/core": "3.10.2",
+                "@docusaurus/logger": "3.10.2",
+                "@docusaurus/plugin-content-docs": "3.10.2",
+                "@docusaurus/theme-common": "3.10.2",
+                "@docusaurus/theme-translations": "3.10.2",
+                "@docusaurus/utils": "3.10.2",
+                "@docusaurus/utils-validation": "3.10.2",
                 "algoliasearch": "^5.37.0",
                 "algoliasearch-helper": "^3.26.0",
                 "clsx": "^2.0.0",
@@ -3989,9 +4003,9 @@
             }
         },
         "node_modules/@docusaurus/theme-translations": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.10.1.tgz",
-            "integrity": "sha512-cLMyaKivjBVWKMJuWqyFVVgtqe8DPJNPkog0bn8W1MDVAKcPdxRFycBfC1We1RaNp7Rdk513bmtW78RR6OBxBw==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.10.2.tgz",
+            "integrity": "sha512-iv20wrxnyXkY89LM3TzRlzGlt5fIGO5UnaR6UL1ZVfB9RRFjxQFQ6awDrwAc6Km8Y5gD8pInuwYPF+6/TiCxXA==",
             "license": "MIT",
             "dependencies": {
                 "fs-extra": "^11.1.1",
@@ -4002,16 +4016,16 @@
             }
         },
         "node_modules/@docusaurus/tsconfig": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.10.1.tgz",
-            "integrity": "sha512-rYvB7yqkdqWIpAbDzQljGfM4cDBkLTbhmagZBEcsyj6oPUsz47lmW2pYdN1j+7sGFgltbAmQH62xfbrij4Eh6Q==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.10.2.tgz",
+            "integrity": "sha512-5GiB7h/nFsMFPO9mCqcRNE1yA5TSXXNCshNIgHPL6fCPOjcTDixs6qjQBu8ddkgPcicwCvOA7n3jeK2rGdJk6g==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@docusaurus/types": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-            "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.2.tgz",
+            "integrity": "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==",
             "license": "MIT",
             "dependencies": {
                 "@mdx-js/mdx": "^3.0.0",
@@ -4045,21 +4059,21 @@
             }
         },
         "node_modules/@docusaurus/utils": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.10.1.tgz",
-            "integrity": "sha512-3ojeJry9xBYdJO6qoyyzqeJFSJBVx2mXhyDzSdjwL2+URFQMf+h25gG38iswGImicK0ELjTd1EL2xzk8hf3QPw==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.10.2.tgz",
+            "integrity": "sha512-xx0W3eav2uW1NRIpuHJWNwLTC15xPNjU4Uxi9NSnd3swYC96BE3vFiT93SD8s24kmAAWNwgZwfZ2fghGZ01Lcw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/logger": "3.10.1",
-                "@docusaurus/types": "3.10.1",
-                "@docusaurus/utils-common": "3.10.1",
+                "@11ty/gray-matter": "^1.0.0",
+                "@docusaurus/logger": "3.10.2",
+                "@docusaurus/types": "3.10.2",
+                "@docusaurus/utils-common": "3.10.2",
                 "escape-string-regexp": "^4.0.0",
                 "execa": "^5.1.1",
                 "file-loader": "^6.2.0",
                 "fs-extra": "^11.1.1",
                 "github-slugger": "^1.5.0",
                 "globby": "^11.1.0",
-                "gray-matter": "^4.0.3",
                 "jiti": "^1.20.0",
                 "js-yaml": "^4.1.0",
                 "lodash": "^4.17.21",
@@ -4077,12 +4091,12 @@
             }
         },
         "node_modules/@docusaurus/utils-common": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.10.1.tgz",
-            "integrity": "sha512-5mFSgEADtnFxFH7RLw02QA5MpU5JVUCj0MPeIvi/aF4Fi45tQRIuTwXoXDqJ+1VfQJuYJGz3SI63wmGz4HvXzA==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.10.2.tgz",
+            "integrity": "sha512-x3Dz6jv6iQKBNjBmVTu8p57abMp/VNTUgKBMgRVXJc5444orBTsArv0+cdfrXTiz/VMmHfDRVkPbL7GH2B7T7w==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/types": "3.10.1",
+                "@docusaurus/types": "3.10.2",
                 "tslib": "^2.6.0"
             },
             "engines": {
@@ -4090,14 +4104,14 @@
             }
         },
         "node_modules/@docusaurus/utils-validation": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.1.tgz",
-            "integrity": "sha512-cRv1X69jwaWv47waglllgZVWzeBFLhl53XT/XED/83BerVBTC5FTP8WTcVl8Z6sZOegDSwitu/wpCSPCDOT6lg==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.2.tgz",
+            "integrity": "sha512-sn8unbDfUL585NtR3cwHefPicOyaHvPaX7VD0aOg/siIxUBoKyKKaGEqzJZDS64mM43TnxurkYDtmB1wsJlZsw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/logger": "3.10.1",
-                "@docusaurus/utils": "3.10.1",
-                "@docusaurus/utils-common": "3.10.1",
+                "@docusaurus/logger": "3.10.2",
+                "@docusaurus/utils": "3.10.2",
+                "@docusaurus/utils-common": "3.10.2",
                 "fs-extra": "^11.2.0",
                 "joi": "^17.9.2",
                 "js-yaml": "^4.1.0",
@@ -4950,9 +4964,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@sinclair/typebox": {
-            "version": "0.27.10",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-            "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+            "version": "0.27.12",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+            "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
             "license": "MIT"
         },
         "node_modules/@sindresorhus/is": {
@@ -5333,12 +5347,6 @@
                 "@types/send": "*"
             }
         },
-        "node_modules/@types/gtag.js": {
-            "version": "0.0.20",
-            "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.20.tgz",
-            "integrity": "sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg==",
-            "license": "MIT"
-        },
         "node_modules/@types/hast": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
@@ -5439,9 +5447,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "26.1.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-            "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+            "version": "26.1.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+            "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~8.3.0"
@@ -5600,9 +5608,9 @@
             "license": "MIT"
         },
         "node_modules/@ungap/structured-clone": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
-            "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+            "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
             "license": "ISC"
         },
         "node_modules/@webassemblyjs/ast": {
@@ -5807,27 +5815,15 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+            "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
             },
             "engines": {
                 "node": ">=0.4.0"
-            }
-        },
-        "node_modules/acorn-import-phases": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-            "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "peerDependencies": {
-                "acorn": "^8.14.0"
             }
         },
         "node_modules/acorn-jsx": {
@@ -5852,12 +5848,12 @@
             }
         },
         "node_modules/address": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
-            "integrity": "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/address/-/address-2.0.3.tgz",
+            "integrity": "sha512-XNAb/a6TCqou+TufU8/u11HCu9x1gYvOoxLwtlXgIqmkrYQADVv6ljyW2zwiPhHz9R1gItAWpuDrdJMmrOBFEA==",
             "license": "MIT",
             "engines": {
-                "node": ">= 10.0.0"
+                "node": ">= 16.0.0"
             }
         },
         "node_modules/aggregate-error": {
@@ -5919,25 +5915,25 @@
             }
         },
         "node_modules/algoliasearch": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.55.2.tgz",
-            "integrity": "sha512-OyacJsaeuLUvGWOynNqYc6sx88XvyoG39wMT8SYqL3l9wwaorDW/LPRbUPfhzw0bWsUWzNCZTnFYOrWFBKsUaw==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.56.0.tgz",
+            "integrity": "sha512-PrqppUmhT4ENdas2pH9caE7efUcxy6EcSFhWzosiVuQBzu2tQ5yLTI6jwomT/1cuBnivzGfxiJCqDNN9FRRh+Q==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/abtesting": "1.21.2",
-                "@algolia/client-abtesting": "5.55.2",
-                "@algolia/client-analytics": "5.55.2",
-                "@algolia/client-common": "5.55.2",
-                "@algolia/client-insights": "5.55.2",
-                "@algolia/client-personalization": "5.55.2",
-                "@algolia/client-query-suggestions": "5.55.2",
-                "@algolia/client-search": "5.55.2",
-                "@algolia/ingestion": "1.55.2",
-                "@algolia/monitoring": "1.55.2",
-                "@algolia/recommend": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "@algolia/abtesting": "1.22.0",
+                "@algolia/client-abtesting": "5.56.0",
+                "@algolia/client-analytics": "5.56.0",
+                "@algolia/client-common": "5.56.0",
+                "@algolia/client-insights": "5.56.0",
+                "@algolia/client-personalization": "5.56.0",
+                "@algolia/client-query-suggestions": "5.56.0",
+                "@algolia/client-search": "5.56.0",
+                "@algolia/ingestion": "1.56.0",
+                "@algolia/monitoring": "1.56.0",
+                "@algolia/recommend": "5.56.0",
+                "@algolia/requester-browser-xhr": "5.56.0",
+                "@algolia/requester-fetch": "5.56.0",
+                "@algolia/requester-node-http": "5.56.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
@@ -6093,9 +6089,9 @@
             }
         },
         "node_modules/autoprefixer": {
-            "version": "10.5.2",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.2.tgz",
-            "integrity": "sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==",
+            "version": "10.5.4",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
+            "integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -6112,8 +6108,8 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.28.4",
-                "caniuse-lite": "^1.0.30001799",
+                "browserslist": "^4.28.6",
+                "caniuse-lite": "^1.0.30001806",
                 "fraction.js": "^5.3.4",
                 "picocolors": "^1.1.1",
                 "postcss-value-parser": "^4.2.0"
@@ -6219,9 +6215,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.42",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
-            "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+            "version": "2.11.7",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.7.tgz",
+            "integrity": "sha512-APw5YuIQAg6L9w4sHDI6j26DGFJI6RpYOhnkMPdC9lWbkKvsyPHzDsve1yd73lk21yz7Y09Kci8B2Pp9FonzWA==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
@@ -6306,9 +6302,9 @@
             "license": "MIT"
         },
         "node_modules/bonjour-service": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.3.tgz",
-            "integrity": "sha512-2Kd5UYlFUVgAKMTyuBLl6w49wqfOnbxHqmuH0oCl/n7TfAikR0zoowNOP5BU4dfXmm+Vr9JyEN370auSMx+CNg==",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.4.tgz",
+            "integrity": "sha512-jCZcVv7eoc4QesRscwEZtSROBen+6LpKAmBIsQYQrsAeVHLyMXWX/t6eIV5KiRZYNUBl8eVqImEEMQ8L5+c/Kw==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -6344,9 +6340,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -6366,9 +6362,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.5",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
-            "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
+            "version": "4.28.7",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+            "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -6385,10 +6381,10 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.10.42",
-                "caniuse-lite": "^1.0.30001800",
-                "electron-to-chromium": "^1.5.387",
-                "node-releases": "^2.0.50",
+                "baseline-browser-mapping": "^2.10.44",
+                "caniuse-lite": "^1.0.30001806",
+                "electron-to-chromium": "^1.5.393",
+                "node-releases": "^2.0.51",
                 "update-browserslist-db": "^1.2.3"
             },
             "bin": {
@@ -6555,9 +6551,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001803",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
-            "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
+            "version": "1.0.30001806",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+            "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -7860,20 +7856,19 @@
             "license": "MIT"
         },
         "node_modules/detect-port": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.6.1.tgz",
-            "integrity": "sha512-CmnVc+Hek2egPx1PeTFVta2W78xy2K/9Rkf6cC4T59S50tVnzKj+tnx5mmx5lwvCkujZ4uRrpRSuV+IVs3f90Q==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-2.1.0.tgz",
+            "integrity": "sha512-epZuWb/6Q62L+nDHJc/hQAqf8pylsqgk3BpZXVBx1CDnr3nkrVNn73Uu1rXcFzkNcc+hkP3whuOg7JZYaQB65Q==",
             "license": "MIT",
             "dependencies": {
-                "address": "^1.0.1",
-                "debug": "4"
+                "address": "^2.0.1"
             },
             "bin": {
-                "detect": "bin/detect-port.js",
-                "detect-port": "bin/detect-port.js"
+                "detect": "dist/commonjs/bin/detect-port.js",
+                "detect-port": "dist/commonjs/bin/detect-port.js"
             },
             "engines": {
-                "node": ">= 4.0.0"
+                "node": ">= 16.0.0"
             }
         },
         "node_modules/devlop": {
@@ -8044,9 +8039,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.389",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
-            "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
+            "version": "1.5.398",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.398.tgz",
+            "integrity": "sha512-AsvhAxopJGh6museTDMIjn6JpDYOfgu4RLlygomt87MUwBUqTfd/1EiPtx10/LZE8xpTvkP2E9Gafq7lkLtodQ==",
             "license": "ISC"
         },
         "node_modules/emoji-regex": {
@@ -8090,9 +8085,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.24.2",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
-            "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
+            "version": "5.24.5",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+            "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -8142,9 +8137,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
-            "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
             "license": "MIT"
         },
         "node_modules/es-object-atoms": {
@@ -8241,19 +8236,6 @@
             },
             "engines": {
                 "node": ">=8.0.0"
-            }
-        },
-        "node_modules/esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "license": "BSD-2-Clause",
-            "bin": {
-                "esparse": "bin/esparse.js",
-                "esvalidate": "bin/esvalidate.js"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/esrecurse": {
@@ -8604,9 +8586,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-            "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
             "funding": [
                 {
                     "type": "github",
@@ -8889,9 +8871,9 @@
             }
         },
         "node_modules/fs-extra": {
-            "version": "11.3.6",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
-            "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
+            "version": "11.4.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+            "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.0",
@@ -9112,43 +9094,6 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "license": "ISC"
-        },
-        "node_modules/gray-matter": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
-            "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
-            "license": "MIT",
-            "dependencies": {
-                "js-yaml": "^3.13.1",
-                "kind-of": "^6.0.2",
-                "section-matter": "^1.0.0",
-                "strip-bom-string": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=6.0"
-            }
-        },
-        "node_modules/gray-matter/node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "license": "MIT",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
-        "node_modules/gray-matter/node_modules/js-yaml": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
         },
         "node_modules/gzip-size": {
             "version": "6.0.0",
@@ -9529,9 +9474,9 @@
             }
         },
         "node_modules/html-webpack-plugin": {
-            "version": "5.6.7",
-            "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.7.tgz",
-            "integrity": "sha512-md+vXtdCAe60s1k6AU3dUyMJnDxUyQAwfwPKoLisvgUF1IXjtlLsk2se54+qfL9Mdm26bbwvjJybpNx48NKRLw==",
+            "version": "5.6.8",
+            "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.8.tgz",
+            "integrity": "sha512-MZmKQcTnhEh1SPSyMiEytIeDZDUoBZVorNHivQGXMASHf/BSGGOrKa2xQ5bGx3TCe1n109ecCt+cpww7wwWhKA==",
             "license": "MIT",
             "dependencies": {
                 "@types/html-minifier-terser": "^6.0.0",
@@ -9548,7 +9493,7 @@
                 "url": "https://opencollective.com/html-webpack-plugin"
             },
             "peerDependencies": {
-                "@rspack/core": "0.x || 1.x",
+                "@rspack/core": "0.x || 1.x || 2.x",
                 "webpack": "^5.20.0"
             },
             "peerDependenciesMeta": {
@@ -10429,19 +10374,6 @@
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "license": "MIT"
-        },
-        "node_modules/loader-runner": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
-            "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.11.5"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
         },
         "node_modules/loader-utils": {
             "version": "2.0.4",
@@ -13074,9 +13006,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.15",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "funding": [
                 {
                     "type": "github",
@@ -13730,9 +13662,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.16",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-            "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+            "version": "8.5.25",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+            "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -13749,7 +13681,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -16235,9 +16167,9 @@
             "license": "MIT"
         },
         "node_modules/sax": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-            "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+            "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=11.0.0"
@@ -16591,9 +16523,9 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
-            "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+            "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -16853,12 +16785,6 @@
                 "wbuf": "^1.7.3"
             }
         },
-        "node_modules/sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-            "license": "BSD-3-Clause"
-        },
         "node_modules/srcset": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/srcset/-/srcset-4.0.0.tgz",
@@ -17074,9 +17000,9 @@
             "license": "MIT"
         },
         "node_modules/svgo": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
-            "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.4.tgz",
+            "integrity": "sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==",
             "license": "MIT",
             "dependencies": {
                 "commander": "^7.2.0",
@@ -17234,9 +17160,9 @@
             "license": "MIT"
         },
         "node_modules/thingies": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.0.tgz",
-            "integrity": "sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.1.tgz",
+            "integrity": "sha512-cV/CMGTK3M4MlnJ/0At6ismOw/A0EEniDNScajjz/Br3c1sqE72YD01rGpPTKwd27wAxI5Pr+6+0w8yofzFRYw==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.18"
@@ -17962,9 +17888,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.108.4",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.4.tgz",
-            "integrity": "sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==",
+            "version": "5.109.2",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.2.tgz",
+            "integrity": "sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==",
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.8",
@@ -17973,22 +17899,20 @@
                 "@webassemblyjs/wasm-edit": "^1.14.1",
                 "@webassemblyjs/wasm-parser": "^1.14.1",
                 "acorn": "^8.16.0",
-                "acorn-import-phases": "^1.0.3",
                 "browserslist": "^4.28.1",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.22.2",
+                "enhanced-resolve": "^5.24.4",
                 "es-module-lexer": "^2.1.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "graceful-fs": "^4.2.11",
-                "loader-runner": "^4.3.2",
                 "mime-db": "^1.54.0",
                 "minimizer-webpack-plugin": "^5.6.1",
                 "neo-async": "^2.6.2",
                 "schema-utils": "^4.3.3",
                 "tapable": "^2.3.0",
                 "watchpack": "^2.5.2",
-                "webpack-sources": "^3.5.0"
+                "webpack-sources": "^3.5.1"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -18196,9 +18120,9 @@
             }
         },
         "node_modules/webpack-dev-server/node_modules/ws": {
-            "version": "8.21.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "version": "8.21.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+            "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -18403,9 +18327,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "7.5.11",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-            "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+            "version": "7.5.13",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+            "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
             "license": "MIT",
             "engines": {
                 "node": ">=8.3.0"

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,16 +14,16 @@
     },
     "dependencies": {
         "@docusaurus/core": "^3.9.2",
-        "@docusaurus/preset-classic": "^3.9.2",
-        "@mdx-js/react": "^3.0.0",
-        "clsx": "^2.0.0",
-        "prism-react-renderer": "^2.3.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "@docusaurus/preset-classic": "^3.10.2",
+        "@mdx-js/react": "^3.1.1",
+        "clsx": "^2.1.1",
+        "prism-react-renderer": "^2.4.1",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
     },
     "devDependencies": {
         "@docusaurus/module-type-aliases": "^3.9.2",
-        "@docusaurus/tsconfig": "^3.9.2",
+        "@docusaurus/tsconfig": "^3.10.2",
         "@docusaurus/types": "^3.9.2",
         "typescript": "~5.6.2"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
                 "eslint": "^9.39.5",
                 "husky": "^9.1.7",
                 "lint-staged": "^17.2.0",
-                "npm-run-all2": "^9.0.2",
+                "npm-run-all2": "^9.0.3",
                 "prettier": "^3.9.6",
                 "typescript": "^5.9.3",
                 "vitest": "^4.1.10"
@@ -811,21 +811,21 @@
             }
         },
         "node_modules/@emnapi/core": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+            "version": "2.0.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+            "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/wasi-threads": "1.2.2",
+                "@emnapi/wasi-threads": "2.0.1",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+            "version": "2.0.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+            "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -834,9 +834,9 @@
             }
         },
         "node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+            "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -2249,9 +2249,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.139.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
-            "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+            "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -2307,9 +2307,9 @@
             "license": "MIT"
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
-            "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.1.tgz",
+            "integrity": "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==",
             "cpu": [
                 "arm64"
             ],
@@ -2324,9 +2324,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
-            "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.1.tgz",
+            "integrity": "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==",
             "cpu": [
                 "arm64"
             ],
@@ -2341,9 +2341,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
-            "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.1.tgz",
+            "integrity": "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==",
             "cpu": [
                 "x64"
             ],
@@ -2358,9 +2358,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
-            "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.1.tgz",
+            "integrity": "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==",
             "cpu": [
                 "x64"
             ],
@@ -2375,9 +2375,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
-            "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.1.tgz",
+            "integrity": "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==",
             "cpu": [
                 "arm"
             ],
@@ -2392,9 +2392,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
-            "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.1.tgz",
+            "integrity": "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==",
             "cpu": [
                 "arm64"
             ],
@@ -2409,9 +2409,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
-            "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.1.tgz",
+            "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
             "cpu": [
                 "arm64"
             ],
@@ -2426,9 +2426,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
-            "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.1.tgz",
+            "integrity": "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==",
             "cpu": [
                 "ppc64"
             ],
@@ -2443,9 +2443,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
-            "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.1.tgz",
+            "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
             "cpu": [
                 "s390x"
             ],
@@ -2460,9 +2460,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
-            "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.1.tgz",
+            "integrity": "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==",
             "cpu": [
                 "x64"
             ],
@@ -2477,9 +2477,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
-            "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.1.tgz",
+            "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
             "cpu": [
                 "x64"
             ],
@@ -2494,9 +2494,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
-            "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.1.tgz",
+            "integrity": "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==",
             "cpu": [
                 "arm64"
             ],
@@ -2511,28 +2511,25 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
-            "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
-            "cpu": [
-                "wasm32"
-            ],
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.1.tgz",
+            "integrity": "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "1.11.1",
-                "@emnapi/runtime": "1.11.1",
-                "@napi-rs/wasm-runtime": "^1.1.6"
+                "@emnapi/core": "2.0.0-alpha.3",
+                "@emnapi/runtime": "2.0.0-alpha.3",
+                "@napi-rs/wasm-runtime": "^1.2.0"
             },
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
-            "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.1.tgz",
+            "integrity": "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==",
             "cpu": [
                 "arm64"
             ],
@@ -2547,9 +2544,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
-            "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.1.tgz",
+            "integrity": "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==",
             "cpu": [
                 "x64"
             ],
@@ -8257,13 +8254,13 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
-            "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.1.tgz",
+            "integrity": "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.139.0",
+                "@oxc-project/types": "=0.142.0",
                 "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
@@ -8273,21 +8270,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.1.5",
-                "@rolldown/binding-darwin-arm64": "1.1.5",
-                "@rolldown/binding-darwin-x64": "1.1.5",
-                "@rolldown/binding-freebsd-x64": "1.1.5",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
-                "@rolldown/binding-linux-arm64-gnu": "1.1.5",
-                "@rolldown/binding-linux-arm64-musl": "1.1.5",
-                "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
-                "@rolldown/binding-linux-s390x-gnu": "1.1.5",
-                "@rolldown/binding-linux-x64-gnu": "1.1.5",
-                "@rolldown/binding-linux-x64-musl": "1.1.5",
-                "@rolldown/binding-openharmony-arm64": "1.1.5",
-                "@rolldown/binding-wasm32-wasi": "1.1.5",
-                "@rolldown/binding-win32-arm64-msvc": "1.1.5",
-                "@rolldown/binding-win32-x64-msvc": "1.1.5"
+                "@rolldown/binding-android-arm64": "1.2.1",
+                "@rolldown/binding-darwin-arm64": "1.2.1",
+                "@rolldown/binding-darwin-x64": "1.2.1",
+                "@rolldown/binding-freebsd-x64": "1.2.1",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.2.1",
+                "@rolldown/binding-linux-arm64-gnu": "1.2.1",
+                "@rolldown/binding-linux-arm64-musl": "1.2.1",
+                "@rolldown/binding-linux-ppc64-gnu": "1.2.1",
+                "@rolldown/binding-linux-s390x-gnu": "1.2.1",
+                "@rolldown/binding-linux-x64-gnu": "1.2.1",
+                "@rolldown/binding-linux-x64-musl": "1.2.1",
+                "@rolldown/binding-openharmony-arm64": "1.2.1",
+                "@rolldown/binding-wasm32-wasi": "1.2.1",
+                "@rolldown/binding-win32-arm64-msvc": "1.2.1",
+                "@rolldown/binding-win32-x64-msvc": "1.2.1"
             }
         },
         "node_modules/run-parallel": {
@@ -9445,16 +9442,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.1.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
-            "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
+            "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "lightningcss": "^1.32.0",
+                "lightningcss": "^1.33.0",
                 "picomatch": "^4.0.5",
-                "postcss": "^8.5.17",
-                "rolldown": "~1.1.5",
+                "postcss": "^8.5.23",
+                "rolldown": "~1.2.0",
                 "tinyglobby": "^0.2.17"
             },
             "bin": {
@@ -9471,7 +9468,7 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.3.0",
+                "@vitejs/devtools": "^0.4.0",
                 "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "eslint": "^9.39.5",
         "husky": "^9.1.7",
         "lint-staged": "^17.2.0",
-        "npm-run-all2": "^9.0.2",
+        "npm-run-all2": "^9.0.3",
         "prettier": "^3.9.6",
         "typescript": "^5.9.3",
         "vitest": "^4.1.10"


### PR DESCRIPTION
## Description

Routine dependency maintenance: run `npm update --save` in both the root package and `docs/` to pull in the latest minor/patch releases within the existing semver ranges, keeping dependencies current and picking up upstream bug fixes.

Changes:
- Root: `npm-run-all2` ^9.0.2 → ^9.0.3 (plus transitive lockfile updates)
- `docs/`: Docusaurus toolchain ^3.9.2 → ^3.10.2 (`@docusaurus/preset-classic`, `@docusaurus/tsconfig`), `@mdx-js/react` ^3.0.0 → ^3.1.1, `clsx` ^2.0.0 → ^2.1.1, `prism-react-renderer` ^2.3.0 → ^2.4.1, `react`/`react-dom` ^18.0.0 → ^18.3.1 (plus transitive lockfile updates)

No major version bumps are included — packages with only major upgrades available (e.g. `typescript`, `eslint`, `react`/`react-dom` to v19) were left untouched since they're outside the current semver ranges.

## Verification

- `npm run build` — passes
- `npm run lint` — passes
- `npm test` — 10/15 pass; the 5 failing e2e tests (`src/dev-pm.e2e.test.ts`) time out spawning child processes and fail identically on `main` before this change, confirming they're a pre-existing environment issue unrelated to this dependency bump
- `docs`: `npm run build` — passes

## Further information

No changeset added — this is a routine dependency bump with no public API or behavior change, consistent with prior dependency-update PRs in this repo (e.g. #196, #186, #185).

---
_Generated by [Claude Code](https://claude.ai/code)_
