### PR TITLE
Restore v3 version and add major changeset

### DIFF
--- a/.changeset/rename-package-and-require-node-22.md
+++ b/.changeset/rename-package-and-require-node-22.md
@@ -1,0 +1,16 @@
+---
+"dev-process-manager": major
+---
+
+Rename the package to `dev-process-manager` and require Node v22 or later
+
+The `@comet` scope has been removed to make clear that the dev-process-manager can be used outside of Comet/Dextinity. Update your dependencies accordingly:
+
+```bash
+npm uninstall @comet/dev-process-manager
+npm install --save-dev dev-process-manager
+```
+
+The `dev-pm` binary, the configuration file and all commands are unchanged.
+
+Additionally, the minimum supported Node version has been raised from v18 to v22.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "dev-process-manager",
-    "version": "1.0.0",
+    "version": "3.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "dev-process-manager",
-            "version": "1.0.0",
+            "version": "3.2.0",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "cli-table3": "^0.6.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "dev-process-manager",
     "license": "BSD-2-Clause",
-    "version": "1.0.0",
+    "version": "3.2.0",
     "exports": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "bin": {


### PR DESCRIPTION
https://github.com/vivid-planet/dev-process-manager/pull/194 changed the package name to `dev-process-manager` and reseted the version to 1.0.0. However, this causes issues with releases and tags. I therefore suggest to not reset to 1.0.0 and instead release 4.0.0, covering the rename and the minimum Node.js version bump in https://github.com/vivid-planet/dev-process-manager/pull/196.

https://claude.ai/code/session_01P3dbAB8yEd7Epi8Qvu2bJP