### PR TITLE
Update package version in lock file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: npm run build-and-publish
+          version: npm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
         "start": "tsc --watch",
         "test": "vitest run",
         "test:watch": "vitest",
-        "build-and-publish": "npm run build && npx changeset publish"
+        "build-and-publish": "npm run build && npx changeset publish",
+        "version": "changeset version && npm install"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
The package's version in the package-lock.json isn't updated when releasing a new version. To fix this, we manually run npm install after determining the new version. We do something similar for Comet: [vivid-planet/comet@02d2ba8/.github/workflows/release.yml#L45](https://github.com/vivid-planet/comet/blob/02d2ba83bcf3e4e139fc7f933ffe91413dfccdd1/.github/workflows/release.yml#L45) and [vivid-planet/comet@02d2ba8/package.json#L44](https://github.com/vivid-planet/comet/blob/02d2ba83bcf3e4e139fc7f933ffe91413dfccdd1/package.json#L44).
https://claude.ai/code/session_01MjG1y5T5x27Bg7nqritFua