### PR TITLE
Move dev-pm skill from Dextinity into this repository

### DIFF
--- a/.changeset/dev-pm-agent-skill.md
+++ b/.changeset/dev-pm-agent-skill.md
@@ -2,4 +2,4 @@
 "dev-process-manager": minor
 ---
 
-Bundle the `dev-pm` AI Agent Skill in the npm package under `skills/dev-pm/`. It can be installed into consuming projects via `skills-npm` or `@comet/cli install-agent-features`.
+Bundle the `dev-pm` AI Agent Skill in the npm package under `skills/dev-pm/`. It can be installed into consuming projects via `skills-npm` or `@dextinity/cli install-agent-features`.

--- a/.changeset/dev-pm-agent-skill.md
+++ b/.changeset/dev-pm-agent-skill.md
@@ -1,0 +1,5 @@
+---
+"dev-process-manager": minor
+---
+
+Bundle the `dev-pm` AI Agent Skill in the npm package under `skills/dev-pm/`. It can be installed into consuming projects via `skills-npm` or `@comet/cli install-agent-features`.

--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ Install it with either installer — both discover the `skills/` folder inside
 # skills-npm (generic installer)
 $ npx skills-npm setup
 
-# or @comet/cli
-$ npx @comet/cli install-agent-features
+# or @dextinity/cli
+$ npx @dextinity/cli install-agent-features
 ```
 
 See the [AI Agent Skills documentation](https://dev-process-manager.com/docs/agent-skills)

--- a/README.md
+++ b/README.md
@@ -124,6 +124,28 @@ Stop all running processes and shutdown dev-pm
 $ npx dev-pm shutdown
 ```
 
+## AI Agent Skills
+
+dev-process-manager ships an [Agent Skill](https://agentskills.io/) that teaches AI coding
+agents (Claude Code, Cursor, GitHub Copilot, …) how to drive `dev-pm` correctly. It is
+bundled inside the npm package under a `skills/` directory (`skills/dev-pm/SKILL.md`), so
+any project that depends on dev-process-manager can install it straight from
+`node_modules`.
+
+Install it with either installer — both discover the `skills/` folder inside
+`node_modules/dev-process-manager` automatically:
+
+```console
+# skills-npm (generic installer)
+$ npx skills-npm setup
+
+# or @comet/cli
+$ npx @comet/cli install-agent-features
+```
+
+See the [AI Agent Skills documentation](https://dev-process-manager.com/docs/agent-skills)
+for details.
+
 ## Development
 
 Use in existing project with

--- a/docs/docs/agent-skills.md
+++ b/docs/docs/agent-skills.md
@@ -42,14 +42,14 @@ npx skills-npm setup
 This adds a `prepare` script and a `.gitignore` entry, then syncs once. From then on the
 `dev-pm` skill is re-linked automatically whenever dependencies are installed.
 
-### Option B — @comet/cli
+### Option B — @dextinity/cli
 
-If your project uses Comet, `@comet/cli` provides the same functionality via
+If your project uses Dextinity, `@dextinity/cli` provides the same functionality via
 `install-agent-features`, which scans your direct `node_modules` dependencies for
 `skills/` folders and installs what it finds:
 
 ```bash
-npx @comet/cli install-agent-features
+npx @dextinity/cli install-agent-features
 ```
 
 ## What the agent learns

--- a/docs/docs/agent-skills.md
+++ b/docs/docs/agent-skills.md
@@ -1,0 +1,91 @@
+---
+id: agent-skills
+title: AI Agent Skills
+sidebar_label: AI Agent Skills
+---
+
+# AI Agent Skills
+
+dev-process-manager ships an **[Agent Skill](https://agentskills.io/)** that teaches AI
+coding agents (Claude Code, Cursor, GitHub Copilot, …) how to drive `dev-pm` correctly —
+starting, stopping and restarting processes, reading `status`, and tailing `logs` without
+hanging the agent on streaming flags.
+
+The skill is bundled inside the npm package under a `skills/` directory:
+
+```
+dev-process-manager/
+└── skills/
+    └── dev-pm/
+        └── SKILL.md
+```
+
+Because it lives in the package itself, any project that has dev-process-manager as a
+direct dependency can install the skill straight from `node_modules` — no separate
+download needed.
+
+## Installing the skill
+
+Pick whichever installer your project already uses. Both discover the `skills/` folder
+inside `node_modules/dev-process-manager` automatically and wire it into the directories
+agents read from (`.claude/skills/`, `.agents/skills/`, …).
+
+### Option A — skills-npm
+
+[`skills-npm`](https://github.com/antfu/skills-npm) is a generic installer that symlinks
+skills shipped by your dependencies into your project. Run the one-time setup:
+
+```bash
+npx skills-npm setup
+```
+
+This adds a `prepare` script and a `.gitignore` entry, then syncs once. From then on the
+`dev-pm` skill is re-linked automatically whenever dependencies are installed.
+
+### Option B — @comet/cli
+
+If your project uses Comet, `@comet/cli` provides the same functionality via
+`install-agent-features`, which scans your direct `node_modules` dependencies for
+`skills/` folders and installs what it finds.
+
+Add an `install-agent-features` script to your root `package.json`:
+
+```json title="package.json"
+{
+    "scripts": {
+        "install-agent-features": "npx @comet/cli install-agent-features"
+    }
+}
+```
+
+Then run it (a `--dry-run` flag previews what would be installed):
+
+```bash
+npm run install-agent-features
+```
+
+`@comet/cli` can also pull the skill directly from this repository instead of from
+`node_modules`. Add an `agent-features.json` at your project root:
+
+```json title="agent-features.json"
+{
+    "repos": ["https://github.com/vivid-planet/dev-process-manager.git"]
+}
+```
+
+Only the `skills/` folder is sparse-fetched from the repository — the rest is never
+downloaded. Append `#<ref>` to pin a branch, tag or commit
+(e.g. `…dev-process-manager.git#v4.0.0`).
+
+## What the agent learns
+
+Once installed, the agent picks the skill up automatically and follows its guidance to:
+
+- Invoke `dev-pm` through the package manager (`npm exec -- dev-pm <command>`).
+- Avoid streaming flags (`--follow`, `--interval`, `logs` without `-n`) that would hang a
+  tool call.
+- Check `status` before starting processes, since the daemon persists across sessions.
+- Read `dev-pm.config.ts` to discover the available scripts and groups.
+
+The directories the installer writes to (`.claude/skills/`, `.agents/skills/`, …) are
+generated on install and should not be committed — add them to your `.gitignore`.

--- a/docs/docs/agent-skills.md
+++ b/docs/docs/agent-skills.md
@@ -46,36 +46,11 @@ This adds a `prepare` script and a `.gitignore` entry, then syncs once. From the
 
 If your project uses Comet, `@comet/cli` provides the same functionality via
 `install-agent-features`, which scans your direct `node_modules` dependencies for
-`skills/` folders and installs what it finds.
-
-Add an `install-agent-features` script to your root `package.json`:
-
-```json title="package.json"
-{
-    "scripts": {
-        "install-agent-features": "npx @comet/cli install-agent-features"
-    }
-}
-```
-
-Then run it (a `--dry-run` flag previews what would be installed):
+`skills/` folders and installs what it finds:
 
 ```bash
-npm run install-agent-features
+npx @comet/cli install-agent-features
 ```
-
-`@comet/cli` can also pull the skill directly from this repository instead of from
-`node_modules`. Add an `agent-features.json` at your project root:
-
-```json title="agent-features.json"
-{
-    "repos": ["https://github.com/vivid-planet/dev-process-manager.git"]
-}
-```
-
-Only the `skills/` folder is sparse-fetched from the repository — the rest is never
-downloaded. Append `#<ref>` to pin a branch, tag or commit
-(e.g. `…dev-process-manager.git#v4.0.0`).
 
 ## What the agent learns
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -94,3 +94,4 @@ dpm shutdown        # stop everything and shut down the daemon
 - Learn the full set of options in [Configuration](./configuration.md).
 - Browse every command in [Commands](./commands.md).
 - Copy a ready-made setup from [Examples](./examples.md).
+- Let AI coding agents drive `dev-pm` with the bundled [AI Agent Skill](./agent-skills.md).

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -30,6 +30,8 @@ dpm start all
 - **Config as code** — a single typed `dev-pm.config.ts` describes everything.
 - **Environment files** — `.env` and `.env.local` are read (with variable expansion) to
   resolve [`waitOn`](./configuration.md#waiton) resources.
+- **AI agent ready** — a bundled [Agent Skill](./agent-skills.md) teaches AI coding agents
+  how to drive `dev-pm` correctly.
 
 ## How it works
 
@@ -47,6 +49,7 @@ them at any time with `dpm logs`.
 - Looking for the full config surface? See the [Configuration](./configuration.md)
   reference.
 - Want to copy-paste something real? Jump to [Examples](./examples.md).
+- Working with AI coding agents? Install the bundled [AI Agent Skill](./agent-skills.md).
 
 :::note
 This project is developed and maintained by

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -9,7 +9,7 @@ const sidebars: SidebarsConfig = {
             type: "category",
             label: "Guides",
             collapsed: false,
-            items: ["getting-started", "configuration", "commands"],
+            items: ["getting-started", "configuration", "commands", "agent-skills"],
         },
         "examples",
     ],

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
         "dev-pm": "lib/dev-pm.js"
     },
     "files": [
-        "lib/**/*"
+        "lib/**/*",
+        "skills/**/*"
     ],
     "scripts": {
         "prepare": "husky",

--- a/skills/dev-pm/SKILL.md
+++ b/skills/dev-pm/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: dev-pm
+description: Run, restart, stop, and inspect logs/status of long-running development processes via dev-pm (dev-process-manager). Use when starting/stopping/restarting services, tailing logs of those processes, or checking which services are running. Do not use for one-off scripts (`npm run X` is fine for those) — dev-pm is for processes that stay alive.
+---
+
+# dev-pm Skill
+
+`dev-pm` (`dev-process-manager`) supervises long-running dev processes (servers, watchers, codegen, storybook, docker, …). Available scripts and groups are defined in `dev-pm.config.ts` at the repo root — read it to discover what can be started.
+
+## Critical rules
+
+1. **Always invoke through the package manager:** `npm exec -- dev-pm <command>`. Never call `dev-pm` directly. If `pnpm` is the active package manager for the project (e.g. a `pnpm-lock.yaml` is present), use `pnpm exec -- dev-pm <command>` instead.
+2. **Never use streaming flags from a tool call — they hang.** `logs` requires `-n` / `--lines <N>`; `status` must not get `--interval`; `start` / `restart` must not get `--follow`.
+3. **Services may already be running.** dev-pm runs as a daemon across sessions — check `status` before starting things again. Same applies to build watchers ("the build watcher is running" means dev-pm is supervising a `build:watch` script); if absent, build the affected package manually.
+4. **dev-pm owns _all_ long-running tasks — including docker.** If a project uses dev-pm, assume every long-lived process (servers, watchers, codegen, **and** `docker compose up`) is wired into `dev-pm.config.ts`. Don't reach for `docker compose up` / `docker compose down` directly — start/stop the corresponding dev-pm script (commonly named `docker`). Exceptions exist; only treat something as outside scope after confirming it's not in `dev-pm.config.ts`.
+
+## Commands
+
+Script/group names below are placeholders; the authoritative list is `dev-pm.config.ts`.
+
+### `start [patterns...]`
+
+```bash
+npm exec -- dev-pm start <script>      # one script
+npm exec -- dev-pm start @<group>      # a group
+npm exec -- dev-pm start <a> <b>       # multiple patterns
+```
+
+- `@`-prefix → group name (from `group: [...]` in the config). Bare → script `name`. Globs (minimatch) work too, e.g. `api-*`.
+- Already-running scripts are a no-op — safe to call again. To force a restart, use `restart`.
+
+### `status` / `list`
+
+```bash
+npm exec -- dev-pm status              # all scripts
+npm exec -- dev-pm status <pattern>    # filter
+```
+
+First stop when troubleshooting "is X running?".
+
+**Reading the output:**
+
+- **Status:**
+    - `Running` — script is up.
+    - `Waiting` — `waitOn` condition unmet (e.g. api waiting for the database, site waiting for the api). Will start when the dependency is ready; if it stays here, the dependency failed — check its logs.
+    - `Backoff` — process crashed; dev-pm is sleeping before respawn. Wait grows as `min(1.3 ^ restartCount, 10)` seconds, capped at 10s. Flapping `Backoff` means broken — read logs and fix the cause; restarting won't help.
+    - `Stopped` — not running (never started or manually stopped).
+- **Restarts:** healthy scripts sit at `0`. Anything `> 0` means dev-pm respawned a crash — pull logs (`logs --lines 300 <name>`).
+
+### `logs` / `log`
+
+```bash
+npm exec -- dev-pm logs --lines 200 <script>
+npm exec -- dev-pm log -n 500 <pattern>
+```
+
+Pick a line count for the question — 100–200 for a quick check, 500+ for startup/error history.
+
+### `restart [patterns...]`
+
+```bash
+npm exec -- dev-pm restart <script>
+npm exec -- dev-pm restart @<group>
+```
+
+Use after rebuilding a package whose consumers cache the old build, or after editing config the running process loaded at startup.
+
+### `stop [patterns...]`
+
+```bash
+npm exec -- dev-pm stop <script>
+npm exec -- dev-pm stop @<group>
+```
+
+Stops the matched scripts; the daemon stays alive.
+
+### `shutdown` / `halt`
+
+```bash
+npm exec -- dev-pm shutdown
+```
+
+Stops everything and shuts down the daemon. Only when the user explicitly asks to "stop everything" / "kill dev-pm". Don't use as a "reset state" hammer — prefer `restart <pattern>`.
+
+## Discovering scripts and groups
+
+`dev-pm.config.ts` exports a `scripts` array. Each entry has:
+
+- `name` — identifier for start/stop/logs.
+- `group` — group names usable with the `@` prefix.
+- `script` — underlying shell command (informational; don't run directly).
+- `waitOn` — files / TCP ports the script waits for (explains startup ordering).
+
+When the user names a service vaguely ("the api"), grep `dev-pm.config.ts` for the matching `name` rather than guessing.
+
+## Common workflows
+
+- **"Why isn't service X responding?"** → `status` → `logs --lines 200 <name>` → `restart <name>` after fixing the cause.
+- **"Edited a package, running service isn't picking it up"** → confirm the package's build watcher is in `status`; if not, build the package or start its watcher; then `restart` the consumer.
+- **"Verify service X still boots"** → `start <name>`, poll `logs --lines N` until the ready line or an error appears.


### PR DESCRIPTION
The dev-pm skill was part of `@dextinity/agent-skills` package although it can be used without Dextinity. This PR moves it out of the Dextinity repository into this repository.

The skill is automatically discoverable by both `skills-npm` and `@dextinity/cli` installers, requiring no additional configuration from consuming projects.

TODO: remove from Dextinity

https://claude.ai/code/session_01GncAQyGie42EHfbhz9RBJD